### PR TITLE
Expose parseWithTokenizer in the interface.

### DIFF
--- a/include/PEGKit/PKParser.h
+++ b/include/PEGKit/PKParser.h
@@ -63,6 +63,7 @@ enum {
 - (id)parseString:(NSString *)input error:(NSError **)outErr;
 - (id)parseStream:(NSInputStream *)input error:(NSError **)outErr;
 - (id)parseTokens:(NSArray *)input error:(NSError **)outErr;
+- (id)parseWithTokenizer:(PKTokenizer *)tokenizer error:(NSError **)outErr;
 
 @property (nonatomic, assign, readonly) id delegate; // weak ref
 @property (nonatomic, retain) PKTokenizer *tokenizer;


### PR DESCRIPTION
This allows callers to use tokenizers other than the PKTokenizer instances
that parseString and parseStream create.