### PR TITLE
Implement PKParser.isEmptyOK.

### DIFF
--- a/include/PEGKit/PKParser.h
+++ b/include/PEGKit/PKParser.h
@@ -33,6 +33,11 @@ extern NSInteger PEGKitRecognitionErrorCode;
 extern NSString * const PEGKitRecognitionTokenMatchFailed;
 extern NSString * const PEGKitRecognitionPredicateFailed;
 
+/**
+ * Returned by the parse* methods if isEmptyOK is set and the input is empty.
+ */
+extern NSString * const PEGKitSuccessfulEmptyParse;
+
 typedef void (^PKSActionBlock)   (void);
 typedef void (^PKSSpeculateBlock)(void);
 typedef BOOL (^PKSPredicateBlock)(void);
@@ -72,4 +77,11 @@ enum {
 @property (nonatomic, assign) BOOL enableActions; // default YES
 @property (nonatomic, assign) BOOL enableAutomaticErrorRecovery; // default NO
 @property (nonatomic, assign) BOOL enableVerboseErrorReporting; // default NO
+
+/**
+ * Set this if you want to accept empty input.
+ * The parse* methods will return PEGKitSuccessfulEmptyParse in this case.
+ */
+@property (nonatomic) BOOL isEmptyOK;
+
 @end

--- a/res/PGClassImplementationTemplate.txt
+++ b/res/PGClassImplementationTemplate.txt
@@ -37,6 +37,18 @@
 {%/for%}}
 {%/if%}
 - (void)start {
+    if (!self.isEmptyOK || [self speculate:^{
+            [self startSpeculate];
+        }]) {
+        [self startSpeculate];
+    }
+    else {
+        [self matchEOF:YES];
+        PUSH(PEGKitSuccessfulEmptyParse);
+    }
+}
+
+- (void)startSpeculate {
 {{beforeAction}}
 {{startMethodBody}}
 {{afterAction}}}

--- a/src/PKParser.m
+++ b/src/PKParser.m
@@ -39,6 +39,7 @@ NSString * const PEGKitErrorLineNumberKey = @"lineNumber";
 NSInteger PEGKitRecognitionErrorCode = 1;
 NSString * const PEGKitRecognitionTokenMatchFailed = @"Failed to match next input token";
 NSString * const PEGKitRecognitionPredicateFailed = @"Predicate failed";
+NSString * const PEGKitSuccessfulEmptyParse = @"PEGKitSuccessfulEmptyParse";
 
 @interface NSObject ()
 - (void)parser:(PKParser *)p didFailToMatch:(PKAssembly *)a;


### PR DESCRIPTION
This can be set so that the parser will accept empty input.
The parse* methods will return PEGKitSuccessfulEmptyParse
in that case.

Note that we need to check that we're actually at the end
of the stream, otherwise we're going to accept every bad
parse as an empty one.