### PR TITLE
Don't set PKTokenizer.string = nil at the end of the parse.

### DIFF
--- a/src/PKParser.m
+++ b/src/PKParser.m
@@ -310,7 +310,6 @@ NSString * const PEGKitRecognitionPredicateFailed = @"Predicate failed";
         self.tokenSource = nil;
         self.tokenSourceIndex = 0;
         self.tokenSourceCount = 0;
-        self.tokenizer.string = nil;
         self.assembly = nil;
         self.lookahead = nil;
         self.markers = nil;


### PR DESCRIPTION
The setter for that field will assert PKTokenizer.stream is nil, which of
course is not true if you're parsing a stream rather than a string.