### PR TITLE
Don't set self.string or self.stream = nil in dealloc if they are already nil.

### DIFF
--- a/src/PKTokenizer.m
+++ b/src/PKTokenizer.m
@@ -145,8 +145,12 @@
 
 
 - (void)dealloc {
-    self.string = nil;
-    self.stream = nil;
+    if (self.string != nil) {
+        self.string = nil;
+    }
+    if (self.stream != nil) {
+        self.stream = nil;
+    }
     self.reader = nil;
     self.tokenizerStates = nil;
     self.numberState = nil;


### PR DESCRIPTION
There are custom setters in PKReader that assert that the counterpart field
is nil.  This means that we're guaranteed to assert if PKTokenizer.dealloc
is ever called because one or other of these fields will be set during init.

I don't understand why I'm the only one who's hitting this.  Is no-one
else freeing their parsers?