### PR TITLE
Make it possible for a PKParser subclass to use ARC

### DIFF
--- a/ParserGenApp/PEGKitParser.m
+++ b/ParserGenApp/PEGKitParser.m
@@ -1,5 +1,6 @@
 #import "PEGKitParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface PEGKitParser ()
@@ -120,489 +121,490 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)start_ {
-    
-    while ([self speculate:^{ [self grammarAction_]; }]) {
-        [self grammarAction_]; 
+    PKParser_weakSelfDecl;
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf grammarAction_];}]) {
+        [PKParser_weakSelf grammarAction_];
     }
     do {
-        [self rule_]; 
-    } while ([self speculate:^{ [self rule_]; }]);
+        [PKParser_weakSelf rule_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf rule_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
 
 - (void)grammarAction_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_AT discard:YES]; 
-    if ([self predicts:PEGKIT_TOKEN_KIND_HKEY, 0]) {
-        [self hKey_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_INTERFACEKEY, 0]) {
-        [self interfaceKey_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_MKEY, 0]) {
-        [self mKey_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_EXTENSIONKEY, 0]) {
-        [self extensionKey_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_IVARSKEY, 0]) {
-        [self ivarsKey_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_IMPLEMENTATIONKEY, 0]) {
-        [self implementationKey_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_INITKEY, 0]) {
-        [self initKey_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_DEALLOCKEY, 0]) {
-        [self deallocKey_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_BEFOREKEY, 0]) {
-        [self beforeKey_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_AFTERKEY, 0]) {
-        [self afterKey_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_AT discard:YES];
+    if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_HKEY, 0]) {
+        [PKParser_weakSelf hKey_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_INTERFACEKEY, 0]) {
+        [PKParser_weakSelf interfaceKey_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_MKEY, 0]) {
+        [PKParser_weakSelf mKey_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_EXTENSIONKEY, 0]) {
+        [PKParser_weakSelf extensionKey_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_IVARSKEY, 0]) {
+        [PKParser_weakSelf ivarsKey_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_IMPLEMENTATIONKEY, 0]) {
+        [PKParser_weakSelf implementationKey_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_INITKEY, 0]) {
+        [PKParser_weakSelf initKey_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_DEALLOCKEY, 0]) {
+        [PKParser_weakSelf deallocKey_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_BEFOREKEY, 0]) {
+        [PKParser_weakSelf beforeKey_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_AFTERKEY, 0]) {
+        [PKParser_weakSelf afterKey_];
     } else {
-        [self raise:@"No viable alternative found in rule 'grammarAction'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'grammarAction'."];
     }
-    [self action_]; 
+    [PKParser_weakSelf action_];
 
     [self fireDelegateSelector:@selector(parser:didMatchGrammarAction:)];
 }
 
 - (void)hKey_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_HKEY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_HKEY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchHKey:)];
 }
 
 - (void)interfaceKey_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_INTERFACEKEY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_INTERFACEKEY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchInterfaceKey:)];
 }
 
 - (void)mKey_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_MKEY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_MKEY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchMKey:)];
 }
 
 - (void)extensionKey_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_EXTENSIONKEY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_EXTENSIONKEY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchExtensionKey:)];
 }
 
 - (void)ivarsKey_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_IVARSKEY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_IVARSKEY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchIvarsKey:)];
 }
 
 - (void)implementationKey_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_IMPLEMENTATIONKEY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_IMPLEMENTATIONKEY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchImplementationKey:)];
 }
 
 - (void)initKey_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_INITKEY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_INITKEY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchInitKey:)];
 }
 
 - (void)deallocKey_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_DEALLOCKEY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_DEALLOCKEY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDeallocKey:)];
 }
 
 - (void)beforeKey_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_BEFOREKEY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_BEFOREKEY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchBeforeKey:)];
 }
 
 - (void)afterKey_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_AFTERKEY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_AFTERKEY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchAfterKey:)];
 }
 
 - (void)rule_ {
-    
-    [self production_]; 
-    while ([self speculate:^{ [self namedAction_]; }]) {
-        [self namedAction_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf production_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf namedAction_];}]) {
+        [PKParser_weakSelf namedAction_];
     }
-    [self match:PEGKIT_TOKEN_KIND_EQUALS discard:NO]; 
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_EQUALS discard:NO];
     if ([self predicts:PEGKIT_TOKEN_KIND_ACTION, 0]) {
-        [self action_]; 
+        [PKParser_weakSelf action_];
     }
-    [self expr_]; 
-    [self match:PEGKIT_TOKEN_KIND_SEMI_COLON discard:YES]; 
+    [PKParser_weakSelf expr_];
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_SEMI_COLON discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchRule:)];
 }
 
 - (void)production_ {
-    
-    [self varProduction_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf varProduction_];
 
     [self fireDelegateSelector:@selector(parser:didMatchProduction:)];
 }
 
 - (void)namedAction_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_AT discard:YES]; 
-    if ([self predicts:PEGKIT_TOKEN_KIND_BEFOREKEY, 0]) {
-        [self beforeKey_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_AFTERKEY, 0]) {
-        [self afterKey_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_AT discard:YES];
+    if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_BEFOREKEY, 0]) {
+        [PKParser_weakSelf beforeKey_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_AFTERKEY, 0]) {
+        [PKParser_weakSelf afterKey_];
     } else {
-        [self raise:@"No viable alternative found in rule 'namedAction'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'namedAction'."];
     }
-    [self action_]; 
+    [PKParser_weakSelf action_];
 
     [self fireDelegateSelector:@selector(parser:didMatchNamedAction:)];
 }
 
 - (void)varProduction_ {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchVarProduction:)];
 }
 
 - (void)expr_ {
-    
-    [self term_]; 
-    while ([self speculate:^{ [self orTerm_]; }]) {
-        [self orTerm_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf term_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf orTerm_];}]) {
+        [PKParser_weakSelf orTerm_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchExpr:)];
 }
 
 - (void)term_ {
-    
+    PKParser_weakSelfDecl;
     if ([self predicts:PEGKIT_TOKEN_KIND_SEMANTICPREDICATE, 0]) {
-        [self semanticPredicate_]; 
+        [PKParser_weakSelf semanticPredicate_];
     }
-    [self factor_]; 
-    while ([self speculate:^{ [self nextFactor_]; }]) {
-        [self nextFactor_]; 
+    [PKParser_weakSelf factor_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf nextFactor_];}]) {
+        [PKParser_weakSelf nextFactor_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchTerm:)];
 }
 
 - (void)orTerm_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_PIPE discard:NO]; 
-    [self term_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_PIPE discard:NO];
+    [PKParser_weakSelf term_];
 
     [self fireDelegateSelector:@selector(parser:didMatchOrTerm:)];
 }
 
 - (void)factor_ {
-    
-    [self phrase_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf phrase_];
     if ([self predicts:PEGKIT_TOKEN_KIND_PHRASEPLUS, PEGKIT_TOKEN_KIND_PHRASEQUESTION, PEGKIT_TOKEN_KIND_PHRASESTAR, 0]) {
-        if ([self predicts:PEGKIT_TOKEN_KIND_PHRASESTAR, 0]) {
-            [self phraseStar_]; 
-        } else if ([self predicts:PEGKIT_TOKEN_KIND_PHRASEPLUS, 0]) {
-            [self phrasePlus_]; 
-        } else if ([self predicts:PEGKIT_TOKEN_KIND_PHRASEQUESTION, 0]) {
-            [self phraseQuestion_]; 
+        if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_PHRASESTAR, 0]) {
+            [PKParser_weakSelf phraseStar_];
+        } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_PHRASEPLUS, 0]) {
+            [PKParser_weakSelf phrasePlus_];
+        } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_PHRASEQUESTION, 0]) {
+            [PKParser_weakSelf phraseQuestion_];
         } else {
-            [self raise:@"No viable alternative found in rule 'factor'."];
+            [PKParser_weakSelf raise:@"No viable alternative found in rule 'factor'."];
         }
     }
     if ([self predicts:PEGKIT_TOKEN_KIND_ACTION, 0]) {
-        [self action_]; 
+        [PKParser_weakSelf action_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchFactor:)];
 }
 
 - (void)nextFactor_ {
-    
-    [self factor_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf factor_];
 
     [self fireDelegateSelector:@selector(parser:didMatchNextFactor:)];
 }
 
 - (void)phrase_ {
-    
-    [self primaryExpr_]; 
-    while ([self speculate:^{ [self predicate_]; }]) {
-        [self predicate_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf primaryExpr_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf predicate_];}]) {
+        [PKParser_weakSelf predicate_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchPhrase:)];
 }
 
 - (void)phraseStar_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_PHRASESTAR discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_PHRASESTAR discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchPhraseStar:)];
 }
 
 - (void)phrasePlus_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_PHRASEPLUS discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_PHRASEPLUS discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchPhrasePlus:)];
 }
 
 - (void)phraseQuestion_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_PHRASEQUESTION discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_PHRASEQUESTION discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchPhraseQuestion:)];
 }
 
 - (void)action_ {
-    
+    PKParser_weakSelfDecl;
     [self match:PEGKIT_TOKEN_KIND_ACTION discard:NO]; 
 
     [self fireDelegateSelector:@selector(parser:didMatchAction:)];
 }
 
 - (void)semanticPredicate_ {
-    
+    PKParser_weakSelfDecl;
     [self match:PEGKIT_TOKEN_KIND_SEMANTICPREDICATE discard:NO]; 
 
     [self fireDelegateSelector:@selector(parser:didMatchSemanticPredicate:)];
 }
 
 - (void)predicate_ {
-    
-    if ([self predicts:PEGKIT_TOKEN_KIND_AMPERSAND, 0]) {
-        [self intersection_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_MINUS, 0]) {
-        [self difference_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_AMPERSAND, 0]) {
+        [PKParser_weakSelf intersection_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_MINUS, 0]) {
+        [PKParser_weakSelf difference_];
     } else {
-        [self raise:@"No viable alternative found in rule 'predicate'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'predicate'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchPredicate:)];
 }
 
 - (void)intersection_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_AMPERSAND discard:YES]; 
-    [self primaryExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_AMPERSAND discard:YES];
+    [PKParser_weakSelf primaryExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchIntersection:)];
 }
 
 - (void)difference_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_MINUS discard:YES]; 
-    [self primaryExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_MINUS discard:YES];
+    [PKParser_weakSelf primaryExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchDifference:)];
 }
 
 - (void)primaryExpr_ {
-    
-    if ([self predicts:PEGKIT_TOKEN_KIND_TILDE, 0]) {
-        [self negatedPrimaryExpr_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_ANY_TITLE, PEGKIT_TOKEN_KIND_CHAR_TITLE, PEGKIT_TOKEN_KIND_COMMENT_TITLE, PEGKIT_TOKEN_KIND_DELIMOPEN, PEGKIT_TOKEN_KIND_DIGIT_TITLE, PEGKIT_TOKEN_KIND_EMAIL_TITLE, PEGKIT_TOKEN_KIND_EMPTY_TITLE, PEGKIT_TOKEN_KIND_EOF_TITLE, PEGKIT_TOKEN_KIND_LETTER_TITLE, PEGKIT_TOKEN_KIND_NUMBER_TITLE, PEGKIT_TOKEN_KIND_OPEN_BRACKET, PEGKIT_TOKEN_KIND_OPEN_PAREN, PEGKIT_TOKEN_KIND_PATTERNIGNORECASE, PEGKIT_TOKEN_KIND_PATTERNNOOPTS, PEGKIT_TOKEN_KIND_QUOTEDSTRING_TITLE, PEGKIT_TOKEN_KIND_SPECIFICCHAR_TITLE, PEGKIT_TOKEN_KIND_SYMBOL_TITLE, PEGKIT_TOKEN_KIND_S_TITLE, PEGKIT_TOKEN_KIND_URL_TITLE, PEGKIT_TOKEN_KIND_WORD_TITLE, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self barePrimaryExpr_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_TILDE, 0]) {
+        [PKParser_weakSelf negatedPrimaryExpr_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_ANY_TITLE, PEGKIT_TOKEN_KIND_CHAR_TITLE, PEGKIT_TOKEN_KIND_COMMENT_TITLE, PEGKIT_TOKEN_KIND_DELIMOPEN, PEGKIT_TOKEN_KIND_DIGIT_TITLE, PEGKIT_TOKEN_KIND_EMAIL_TITLE, PEGKIT_TOKEN_KIND_EMPTY_TITLE, PEGKIT_TOKEN_KIND_EOF_TITLE, PEGKIT_TOKEN_KIND_LETTER_TITLE, PEGKIT_TOKEN_KIND_NUMBER_TITLE, PEGKIT_TOKEN_KIND_OPEN_BRACKET, PEGKIT_TOKEN_KIND_OPEN_PAREN, PEGKIT_TOKEN_KIND_PATTERNIGNORECASE, PEGKIT_TOKEN_KIND_PATTERNNOOPTS, PEGKIT_TOKEN_KIND_QUOTEDSTRING_TITLE, PEGKIT_TOKEN_KIND_SPECIFICCHAR_TITLE, PEGKIT_TOKEN_KIND_SYMBOL_TITLE, PEGKIT_TOKEN_KIND_S_TITLE, PEGKIT_TOKEN_KIND_URL_TITLE, PEGKIT_TOKEN_KIND_WORD_TITLE, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf barePrimaryExpr_];
     } else {
-        [self raise:@"No viable alternative found in rule 'primaryExpr'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'primaryExpr'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchPrimaryExpr:)];
 }
 
 - (void)negatedPrimaryExpr_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_TILDE discard:YES]; 
-    [self barePrimaryExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_TILDE discard:YES];
+    [PKParser_weakSelf barePrimaryExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchNegatedPrimaryExpr:)];
 }
 
 - (void)barePrimaryExpr_ {
-    
-    if ([self predicts:PEGKIT_TOKEN_KIND_ANY_TITLE, PEGKIT_TOKEN_KIND_CHAR_TITLE, PEGKIT_TOKEN_KIND_COMMENT_TITLE, PEGKIT_TOKEN_KIND_DELIMOPEN, PEGKIT_TOKEN_KIND_DIGIT_TITLE, PEGKIT_TOKEN_KIND_EMAIL_TITLE, PEGKIT_TOKEN_KIND_EMPTY_TITLE, PEGKIT_TOKEN_KIND_EOF_TITLE, PEGKIT_TOKEN_KIND_LETTER_TITLE, PEGKIT_TOKEN_KIND_NUMBER_TITLE, PEGKIT_TOKEN_KIND_PATTERNIGNORECASE, PEGKIT_TOKEN_KIND_PATTERNNOOPTS, PEGKIT_TOKEN_KIND_QUOTEDSTRING_TITLE, PEGKIT_TOKEN_KIND_SPECIFICCHAR_TITLE, PEGKIT_TOKEN_KIND_SYMBOL_TITLE, PEGKIT_TOKEN_KIND_S_TITLE, PEGKIT_TOKEN_KIND_URL_TITLE, PEGKIT_TOKEN_KIND_WORD_TITLE, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self atomicValue_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_OPEN_PAREN, 0]) {
-        [self subSeqExpr_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_OPEN_BRACKET, 0]) {
-        [self subTrackExpr_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_ANY_TITLE, PEGKIT_TOKEN_KIND_CHAR_TITLE, PEGKIT_TOKEN_KIND_COMMENT_TITLE, PEGKIT_TOKEN_KIND_DELIMOPEN, PEGKIT_TOKEN_KIND_DIGIT_TITLE, PEGKIT_TOKEN_KIND_EMAIL_TITLE, PEGKIT_TOKEN_KIND_EMPTY_TITLE, PEGKIT_TOKEN_KIND_EOF_TITLE, PEGKIT_TOKEN_KIND_LETTER_TITLE, PEGKIT_TOKEN_KIND_NUMBER_TITLE, PEGKIT_TOKEN_KIND_PATTERNIGNORECASE, PEGKIT_TOKEN_KIND_PATTERNNOOPTS, PEGKIT_TOKEN_KIND_QUOTEDSTRING_TITLE, PEGKIT_TOKEN_KIND_SPECIFICCHAR_TITLE, PEGKIT_TOKEN_KIND_SYMBOL_TITLE, PEGKIT_TOKEN_KIND_S_TITLE, PEGKIT_TOKEN_KIND_URL_TITLE, PEGKIT_TOKEN_KIND_WORD_TITLE, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf atomicValue_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_OPEN_PAREN, 0]) {
+        [PKParser_weakSelf subSeqExpr_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_OPEN_BRACKET, 0]) {
+        [PKParser_weakSelf subTrackExpr_];
     } else {
-        [self raise:@"No viable alternative found in rule 'barePrimaryExpr'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'barePrimaryExpr'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchBarePrimaryExpr:)];
 }
 
 - (void)subSeqExpr_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_OPEN_PAREN discard:NO]; 
-    [self expr_]; 
-    [self match:PEGKIT_TOKEN_KIND_CLOSE_PAREN discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_OPEN_PAREN discard:NO];
+    [PKParser_weakSelf expr_];
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_CLOSE_PAREN discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchSubSeqExpr:)];
 }
 
 - (void)subTrackExpr_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_OPEN_BRACKET discard:NO]; 
-    [self expr_]; 
-    [self match:PEGKIT_TOKEN_KIND_CLOSE_BRACKET discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_OPEN_BRACKET discard:NO];
+    [PKParser_weakSelf expr_];
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_CLOSE_BRACKET discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchSubTrackExpr:)];
 }
 
 - (void)atomicValue_ {
-    
-    [self parser_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf parser_];
     if ([self predicts:PEGKIT_TOKEN_KIND_DISCARD, 0]) {
-        [self discard_]; 
+        [PKParser_weakSelf discard_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAtomicValue:)];
 }
 
 - (void)parser_ {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self variable_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self literal_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_PATTERNIGNORECASE, PEGKIT_TOKEN_KIND_PATTERNNOOPTS, 0]) {
-        [self pattern_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_DELIMOPEN, 0]) {
-        [self delimitedString_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_ANY_TITLE, PEGKIT_TOKEN_KIND_CHAR_TITLE, PEGKIT_TOKEN_KIND_COMMENT_TITLE, PEGKIT_TOKEN_KIND_DIGIT_TITLE, PEGKIT_TOKEN_KIND_EMAIL_TITLE, PEGKIT_TOKEN_KIND_EMPTY_TITLE, PEGKIT_TOKEN_KIND_EOF_TITLE, PEGKIT_TOKEN_KIND_LETTER_TITLE, PEGKIT_TOKEN_KIND_NUMBER_TITLE, PEGKIT_TOKEN_KIND_QUOTEDSTRING_TITLE, PEGKIT_TOKEN_KIND_SPECIFICCHAR_TITLE, PEGKIT_TOKEN_KIND_SYMBOL_TITLE, PEGKIT_TOKEN_KIND_S_TITLE, PEGKIT_TOKEN_KIND_URL_TITLE, PEGKIT_TOKEN_KIND_WORD_TITLE, 0]) {
-        [self constant_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf variable_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf literal_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_PATTERNIGNORECASE, PEGKIT_TOKEN_KIND_PATTERNNOOPTS, 0]) {
+        [PKParser_weakSelf pattern_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_DELIMOPEN, 0]) {
+        [PKParser_weakSelf delimitedString_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_ANY_TITLE, PEGKIT_TOKEN_KIND_CHAR_TITLE, PEGKIT_TOKEN_KIND_COMMENT_TITLE, PEGKIT_TOKEN_KIND_DIGIT_TITLE, PEGKIT_TOKEN_KIND_EMAIL_TITLE, PEGKIT_TOKEN_KIND_EMPTY_TITLE, PEGKIT_TOKEN_KIND_EOF_TITLE, PEGKIT_TOKEN_KIND_LETTER_TITLE, PEGKIT_TOKEN_KIND_NUMBER_TITLE, PEGKIT_TOKEN_KIND_QUOTEDSTRING_TITLE, PEGKIT_TOKEN_KIND_SPECIFICCHAR_TITLE, PEGKIT_TOKEN_KIND_SYMBOL_TITLE, PEGKIT_TOKEN_KIND_S_TITLE, PEGKIT_TOKEN_KIND_URL_TITLE, PEGKIT_TOKEN_KIND_WORD_TITLE, 0]) {
+        [PKParser_weakSelf constant_];
     } else {
-        [self raise:@"No viable alternative found in rule 'parser'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'parser'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchParser:)];
 }
 
 - (void)discard_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_DISCARD discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_DISCARD discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchDiscard:)];
 }
 
 - (void)pattern_ {
-    
-    if ([self predicts:PEGKIT_TOKEN_KIND_PATTERNNOOPTS, 0]) {
-        [self patternNoOpts_]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_PATTERNIGNORECASE, 0]) {
-        [self patternIgnoreCase_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_PATTERNNOOPTS, 0]) {
+        [PKParser_weakSelf patternNoOpts_];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_PATTERNIGNORECASE, 0]) {
+        [PKParser_weakSelf patternIgnoreCase_];
     } else {
-        [self raise:@"No viable alternative found in rule 'pattern'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'pattern'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchPattern:)];
 }
 
 - (void)patternNoOpts_ {
-    
+    PKParser_weakSelfDecl;
     [self match:PEGKIT_TOKEN_KIND_PATTERNNOOPTS discard:NO]; 
 
     [self fireDelegateSelector:@selector(parser:didMatchPatternNoOpts:)];
 }
 
 - (void)patternIgnoreCase_ {
-    
+    PKParser_weakSelfDecl;
     [self match:PEGKIT_TOKEN_KIND_PATTERNIGNORECASE discard:NO]; 
 
     [self fireDelegateSelector:@selector(parser:didMatchPatternIgnoreCase:)];
 }
 
 - (void)delimitedString_ {
-    
-    [self delimOpen_]; 
-    [self matchQuotedString:NO]; 
-    if ([self speculate:^{ [self match:PEGKIT_TOKEN_KIND_COMMA discard:YES]; [self matchQuotedString:NO]; }]) {
-        [self match:PEGKIT_TOKEN_KIND_COMMA discard:YES]; 
-        [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf delimOpen_];
+    [PKParser_weakSelf matchQuotedString:NO];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_COMMA discard:YES];[PKParser_weakSelf matchQuotedString:NO];}]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_COMMA discard:YES];
+        [PKParser_weakSelf matchQuotedString:NO];
     }
-    [self match:PEGKIT_TOKEN_KIND_CLOSE_CURLY discard:YES]; 
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_CLOSE_CURLY discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchDelimitedString:)];
 }
 
 - (void)literal_ {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLiteral:)];
 }
 
 - (void)constant_ {
-    
-    if ([self predicts:PEGKIT_TOKEN_KIND_EOF_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_EOF_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_WORD_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_WORD_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_NUMBER_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_NUMBER_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_QUOTEDSTRING_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_QUOTEDSTRING_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_SYMBOL_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_SYMBOL_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_COMMENT_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_COMMENT_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_EMPTY_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_EMPTY_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_ANY_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_ANY_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_S_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_S_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_URL_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_URL_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_EMAIL_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_EMAIL_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_DIGIT_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_DIGIT_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_LETTER_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_LETTER_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_CHAR_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_CHAR_TITLE discard:NO]; 
-    } else if ([self predicts:PEGKIT_TOKEN_KIND_SPECIFICCHAR_TITLE, 0]) {
-        [self match:PEGKIT_TOKEN_KIND_SPECIFICCHAR_TITLE discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_EOF_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_EOF_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_WORD_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_WORD_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_NUMBER_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_NUMBER_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_QUOTEDSTRING_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_QUOTEDSTRING_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_SYMBOL_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_SYMBOL_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_COMMENT_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_COMMENT_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_EMPTY_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_EMPTY_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_ANY_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_ANY_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_S_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_S_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_URL_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_URL_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_EMAIL_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_EMAIL_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_DIGIT_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_DIGIT_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_LETTER_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_LETTER_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_CHAR_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_CHAR_TITLE discard:NO];
+    } else if ([PKParser_weakSelf predicts:PEGKIT_TOKEN_KIND_SPECIFICCHAR_TITLE, 0]) {
+        [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_SPECIFICCHAR_TITLE discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'constant'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'constant'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchConstant:)];
 }
 
 - (void)variable_ {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchVariable:)];
 }
 
 - (void)delimOpen_ {
-    
-    [self match:PEGKIT_TOKEN_KIND_DELIMOPEN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:PEGKIT_TOKEN_KIND_DELIMOPEN discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDelimOpen:)];
 }

--- a/include/PEGKit/PKParser+Subclass.h
+++ b/include/PEGKit/PKParser+Subclass.h
@@ -101,30 +101,37 @@
 @property (nonatomic, retain) NSString *braces;
 @end
 
-#define LT(i) [self LT:(i)]
-#define LA(i) [self LA:(i)]
-#define LS(i) [self LS:(i)]
-#define LD(i) [self LD:(i)]
+#if __has_feature(objc_arc)
+#define PKParser_weakSelfDecl __unused typeof (self) __weak PKParser_weakSelf = self
+#else
+#define PKParser_weakSelfDecl
+#define PKParser_weakSelf self
+#endif
 
-#define POP()            [self.assembly pop]
-#define POP_STR()        [self popString]
-#define POP_QUOTED_STR() [self popQuotedString]
-#define POP_TOK()        [self popToken]
-#define POP_BOOL()       [self popBool]
-#define POP_INT()        [self popInteger]
-#define POP_UINT()       [self popUnsignedInteger]
-#define POP_FLOAT()      [self popFloat]
-#define POP_DOUBLE()     [self popDouble]
+#define LT(i) [PKParser_weakSelf LT:(i)]
+#define LA(i) [PKParser_weakSelf LA:(i)]
+#define LS(i) [PKParser_weakSelf LS:(i)]
+#define LD(i) [PKParser_weakSelf LD:(i)]
 
-#define PUSH(obj)      [self.assembly push:(id)(obj)]
-#define PUSH_BOOL(yn)  [self pushBool:(BOOL)(yn)]
-#define PUSH_INT(i)    [self pushInteger:(NSInteger)(i)]
-#define PUSH_UINT(u)   [self pushUnsignedInteger:(NSUInteger)(u)]
-#define PUSH_FLOAT(f)  [self pushFloat:(float)(f)]
-#define PUSH_DOUBLE(d) [self pushDouble:(double)(d)]
-#define PUSH_ALL(a)    [self pushAll:(a)]
+#define POP()            [PKParser_weakSelf.assembly pop]
+#define POP_STR()        [PKParser_weakSelf popString]
+#define POP_QUOTED_STR() [PKParser_weakSelf popQuotedString]
+#define POP_TOK()        [PKParser_weakSelf popToken]
+#define POP_BOOL()       [PKParser_weakSelf popBool]
+#define POP_INT()        [PKParser_weakSelf popInteger]
+#define POP_UINT()       [PKParser_weakSelf popUnsignedInteger]
+#define POP_FLOAT()      [PKParser_weakSelf popFloat]
+#define POP_DOUBLE()     [PKParser_weakSelf popDouble]
 
-#define REV(a) [self reversedArray:a]
+#define PUSH(obj)      [PKParser_weakSelf.assembly push:(id)(obj)]
+#define PUSH_BOOL(yn)  [PKParser_weakSelf pushBool:(BOOL)(yn)]
+#define PUSH_INT(i)    [PKParser_weakSelf pushInteger:(NSInteger)(i)]
+#define PUSH_UINT(u)   [PKParser_weakSelf pushUnsignedInteger:(NSUInteger)(u)]
+#define PUSH_FLOAT(f)  [PKParser_weakSelf pushFloat:(float)(f)]
+#define PUSH_DOUBLE(d) [PKParser_weakSelf pushDouble:(double)(d)]
+#define PUSH_ALL(a)    [PKParser_weakSelf pushAll:(a)]
+
+#define REV(a) [PKParser_weakSelf reversedArray:a]
 
 #define EQ(a, b) [(a) isEqual:(b)]
 #define NE(a, b) (![(a) isEqual:(b)])
@@ -133,8 +140,8 @@
 #define MATCHES(pattern, str)               ([[NSRegularExpression regularExpressionWithPattern:(pattern) options:0                                  error:nil] numberOfMatchesInString:(str) options:0 range:NSMakeRange(0, [(str) length])] > 0)
 #define MATCHES_IGNORE_CASE(pattern, str)   ([[NSRegularExpression regularExpressionWithPattern:(pattern) options:NSRegularExpressionCaseInsensitive error:nil] numberOfMatchesInString:(str) options:0 range:NSMakeRange(0, [(str) length])] > 0)
 
-#define ABOVE(fence) [self.assembly objectsAbove:(fence)]
-#define EMPTY() [self.assembly isStackEmpty]
+#define ABOVE(fence) [PKParser_weakSelf.assembly objectsAbove:(fence)]
+#define EMPTY() [PKParser_weakSelf.assembly isStackEmpty]
 
 #define LOG(obj) do { NSLog(@"%@", (obj)); } while (0);
 #define PRINT(str) do { printf("%s\n", (str)); } while (0);

--- a/res/PGActionTemplate.txt
+++ b/res/PGActionTemplate.txt
@@ -1,3 +1,3 @@
-{%for i in 1 to depth %}    {%/for%}[self execute:^{
+{%for i in 1 to depth %}    {%/for%}[PKParser_weakSelf execute:^{
 {%for i in 1 to depth %}    {%/for%}{{actionBody}}
 {%for i in 1 to depth %}    {%/for%}}];

--- a/res/PGClassImplementationTemplate.txt
+++ b/res/PGClassImplementationTemplate.txt
@@ -1,5 +1,6 @@
 #import "{{className}}.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 {{mAction}}
 
 @interface {{className}} ()
@@ -37,6 +38,7 @@
 {%/for%}}
 {%/if%}
 - (void)start {
+    PKParser_weakSelfDecl;
 {{beforeAction}}
 {{startMethodBody}}
 {{afterAction}}}

--- a/res/PGConstantMethodCallTemplate.txt
+++ b/res/PGConstantMethodCallTemplate.txt
@@ -1,1 +1,1 @@
-{%for i in 1 to depth %}    {%/for%}[self match{{methodName}}:{%if discard %}YES{%else%}NO{%/if%}]; 
+{%for i in 1 to depth %}    {%/for%}[PKParser_weakSelf match{{methodName}}:{%if discard %}YES{%else%}NO{%/if%}];

--- a/res/PGEOFCallTemplate.txt
+++ b/res/PGEOFCallTemplate.txt
@@ -1,1 +1,1 @@
-{%for i in 1 to depth %}    {%/for%}[self matchEOF:YES]; 
+{%for i in 1 to depth %}    {%/for%}[PKParser_weakSelf matchEOF:YES];

--- a/res/PGMatchCallTemplate.txt
+++ b/res/PGMatchCallTemplate.txt
@@ -1,1 +1,1 @@
-{%for i in 1 to depth %}    {%/for%}[self match:{{tokenKind.name}} discard:{%if discard %}YES{%else%}NO{%/if%}]; 
+{%for i in 1 to depth %}    {%/for%}[PKParser_weakSelf match:{{tokenKind.name}} discard:{%if discard %}YES{%else%}NO{%/if%}];

--- a/res/PGMatchPatternTemplate.txt
+++ b/res/PGMatchPatternTemplate.txt
@@ -10,7 +10,7 @@
 {%for i in 1 to depth %}    {%/for%}NSString *str = LS(1);
 {%for i in 1 to depth %}    {%/for%}
 {%for i in 1 to depth %}    {%/for%}if ({%if predicate %}{{predicate}} && ({%/if%}[regex numberOfMatchesInString:str options:0 range:NSMakeRange(0, [str length])]{%if predicate %}){%/if%}) {
-{%for i in 1 to depth %}    {%/for%}    [self match:TOKEN_KIND_BUILTIN_ANY discard:{%if discard %}YES{%else%}NO{%/if%}];
+{%for i in 1 to depth %}    {%/for%}    [PKParser_weakSelf match:TOKEN_KIND_BUILTIN_ANY discard:{%if discard %}YES{%else%}NO{%/if%}];
 {%for i in 1 to depth %}    {%/for%}} else {
-{%for i in 1 to depth %}    {%/for%}    [self raise:@"pattern test failed in {{methodName}}"];
+{%for i in 1 to depth %}    {%/for%}    [PKParser_weakSelf raise:@"pattern test failed in {{methodName}}"];
 {%for i in 1 to depth %}    {%/for%}}

--- a/res/PGMethodCallTemplate.txt
+++ b/res/PGMethodCallTemplate.txt
@@ -1,1 +1,1 @@
-{%for i in 1 to depth %}    {%/for%}[self {{methodName}}_]; 
+{%for i in 1 to depth %}    {%/for%}[PKParser_weakSelf {{methodName}}_];

--- a/res/PGMethodMemoizationTemplate.txt
+++ b/res/PGMethodMemoizationTemplate.txt
@@ -1,6 +1,6 @@
 
 - (void)__{{methodName}} {
-    
+    PKParser_weakSelfDecl;
 {{preCallback}}{{methodBody}}{{postCallback}}
 }
 

--- a/res/PGMethodSpeculateTemplate.txt
+++ b/res/PGMethodSpeculateTemplate.txt
@@ -1,3 +1,3 @@
-{%for i in 1 to depth %}    {%/for%}if ([self speculate:^{ [self {{methodName}}_]; }]) {
-{%for i in 1 to depth %}    {%/for%}    [self {{methodName}}_];
+{%for i in 1 to depth %}    {%/for%}if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf {{methodName}}_]; }]) {
+{%for i in 1 to depth %}    {%/for%}    [PKParser_weakSelf {{methodName}}_];
 {%for i in 1 to depth %}    {%/for%}}

--- a/res/PGMethodTemplate.txt
+++ b/res/PGMethodTemplate.txt
@@ -1,5 +1,5 @@
 
 - (void){{methodName}}_ {
-    
+    PKParser_weakSelfDecl;
 {{preCallback}}{{methodBody}}{{postCallback}}
 }

--- a/res/PGMultipleSpeculateTemplate.txt
+++ b/res/PGMultipleSpeculateTemplate.txt
@@ -1,2 +1,2 @@
 {%for i in 1 to depth %}    {%/for%}do {
-{{childString}}{%for i in 1 to depth %}    {%/for%}} while ([self speculate:^{ {{ifTest}}}]);
+{{childString}}{%for i in 1 to depth %}    {%/for%}} while ([PKParser_weakSelf speculate:^{ {{ifTest}}}]);

--- a/res/PGNegationSpeculateTemplate.txt
+++ b/res/PGNegationSpeculateTemplate.txt
@@ -1,5 +1,5 @@
-{%for i in 1 to depth %}    {%/for%}if (![self speculate:^{ {%if predicate %}{{predicate}}; {%/if%}{{ifTest}}}]) {
-{%for i in 1 to depth %}    {%/for%}    [self match:TOKEN_KIND_BUILTIN_ANY discard:{%if discard %}YES{%else%}NO{%/if%}];
+{%for i in 1 to depth %}    {%/for%}if (![PKParser_weakSelf speculate:^{ {%if predicate %}{{predicate}}; {%/if%}{{ifTest}}}]) {
+{%for i in 1 to depth %}    {%/for%}    [PKParser_weakSelf match:TOKEN_KIND_BUILTIN_ANY discard:{%if discard %}YES{%else%}NO{%/if%}];
 {%for i in 1 to depth %}    {%/for%}} else {
-{%for i in 1 to depth %}    {%/for%}    [self raise:@"negation test failed in {{methodName}}"];
+{%for i in 1 to depth %}    {%/for%}    [PKParser_weakSelf raise:@"negation test failed in {{methodName}}"];
 {%for i in 1 to depth %}    {%/for%}}

--- a/res/PGOptionalSpeculateTemplate.txt
+++ b/res/PGOptionalSpeculateTemplate.txt
@@ -1,2 +1,2 @@
-{%for i in 1 to depth %}    {%/for%}if ([self speculate:^{ {{ifTest}}}]) {
+{%for i in 1 to depth %}    {%/for%}if ([PKParser_weakSelf speculate:^{ {{ifTest}}}]) {
 {{childString}}{%for i in 1 to depth %}    {%/for%}}

--- a/res/PGPredictElseIfTemplate.txt
+++ b/res/PGPredictElseIfTemplate.txt
@@ -1,1 +1,1 @@
-{%for i in 1 to depth %}    {%/for%}} else if ({%if predicate %}{{predicate}} && ({%/if%}{%if isNegation %}!{%/if%}[self predicts:{%for tokenKind in lookaheadSet%}{{tokenKind.name}}, {%if currentLoop.currentIndex == last %}0]{%/if%}{%/for%}{%if predicate %}){%/if%}) {
+{%for i in 1 to depth %}    {%/for%}} else if ({%if predicate %}{{predicate}} && ({%/if%}{%if isNegation %}!{%/if%}[PKParser_weakSelf predicts:{%for tokenKind in lookaheadSet%}{{tokenKind.name}}, {%if currentLoop.currentIndex == last %}0]{%/if%}{%/for%}{%if predicate %}){%/if%}) {

--- a/res/PGPredictElseTemplate.txt
+++ b/res/PGPredictElseTemplate.txt
@@ -1,3 +1,3 @@
 {%for i in 1 to depth %}    {%/for%}} else {
-{%for i in 1 to depth %}    {%/for%}    [self raise:@"No viable alternative found in rule '{{methodName}}'."];
+{%for i in 1 to depth %}    {%/for%}    [PKParser_weakSelf raise:@"No viable alternative found in rule '{{methodName}}'."];
 {%for i in 1 to depth %}    {%/for%}}

--- a/res/PGPredictIfTemplate.txt
+++ b/res/PGPredictIfTemplate.txt
@@ -1,1 +1,1 @@
-{%for i in 1 to depth %}    {%/for%}if ({%if predicate %}{{predicate}} && ({%/if%}{%if isNegation%}!{%/if%}[self predicts:{%for tokenKind in lookaheadSet%}{{tokenKind.name}}, {%if currentLoop.currentIndex == last %}0]{%/if%}{%/for%}{%if predicate %}){%/if%}) {
+{%for i in 1 to depth %}    {%/for%}if ({%if predicate %}{{predicate}} && ({%/if%}{%if isNegation%}!{%/if%}[PKParser_weakSelf predicts:{%for tokenKind in lookaheadSet%}{{tokenKind.name}}, {%if currentLoop.currentIndex == last %}0]{%/if%}{%/for%}{%if predicate %}){%/if%}) {

--- a/res/PGRepetitionSpeculateTemplate.txt
+++ b/res/PGRepetitionSpeculateTemplate.txt
@@ -1,2 +1,2 @@
-{%for i in 1 to depth %}    {%/for%}while ([self speculate:^{ {{ifTest}}}]) {
+{%for i in 1 to depth %}    {%/for%}while ([PKParser_weakSelf speculate:^{ {{ifTest}}}]) {
 {{childString}}{%for i in 1 to depth %}    {%/for%}}

--- a/res/PGSpeculateElseIfTemplate.txt
+++ b/res/PGSpeculateElseIfTemplate.txt
@@ -1,1 +1,1 @@
-{%for i in 1 to depth %}    {%/for%}} else if ([self speculate:^{ {%if predicate %}{{predicate}}; {%/if%}{{childString}}}]) {
+{%for i in 1 to depth %}    {%/for%}} else if ([PKParser_weakSelf speculate:^{ {%if predicate %}{{predicate}}; {%/if%}{{childString}}}]) {

--- a/res/PGSpeculateIfTemplate.txt
+++ b/res/PGSpeculateIfTemplate.txt
@@ -1,1 +1,1 @@
-{%for i in 1 to depth %}    {%/for%}if ([self speculate:^{ {%if predicate %}{{predicate}}; {%/if%}{{childString}}}]) {
+{%for i in 1 to depth %}    {%/for%}if ([PKParser_weakSelf speculate:^{ {%if predicate %}{{predicate}}; {%/if%}{{childString}}}]) {

--- a/test/AltParser.m
+++ b/test/AltParser.m
@@ -1,5 +1,6 @@
 #import "AltParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface AltParser ()
@@ -63,15 +64,16 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__start {
-    
-    [self s_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf s_];
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
@@ -81,13 +83,13 @@
 }
 
 - (void)__s {
-    
-    if ([self speculate:^{ [self a_]; }]) {
-        [self a_]; 
-    } else if ([self speculate:^{ [self b_]; }]) {
-        [self b_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf a_];}]) {
+        [PKParser_weakSelf a_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf b_];}]) {
+        [PKParser_weakSelf b_];
     } else {
-        [self raise:@"No viable alternative found in rule 's'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 's'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchS:)];
@@ -98,9 +100,9 @@
 }
 
 - (void)__a {
-    
-    [self foo_]; 
-    [self baz_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf foo_];
+    [PKParser_weakSelf baz_];
 
     [self fireDelegateSelector:@selector(parser:didMatchA:)];
 }
@@ -110,14 +112,14 @@
 }
 
 - (void)__b {
-    
-    if ([self speculate:^{ [self a_]; }]) {
-        [self a_]; 
-    } else if ([self speculate:^{ [self foo_]; [self bar_]; }]) {
-        [self foo_]; 
-        [self bar_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf a_];}]) {
+        [PKParser_weakSelf a_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf foo_];[PKParser_weakSelf bar_];}]) {
+        [PKParser_weakSelf foo_];
+        [PKParser_weakSelf bar_];
     } else {
-        [self raise:@"No viable alternative found in rule 'b'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'b'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchB:)];
@@ -128,8 +130,8 @@
 }
 
 - (void)__foo {
-    
-    [self match:ALT_TOKEN_KIND_FOO discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ALT_TOKEN_KIND_FOO discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchFoo:)];
 }
@@ -139,8 +141,8 @@
 }
 
 - (void)__bar {
-    
-    [self match:ALT_TOKEN_KIND_BAR discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ALT_TOKEN_KIND_BAR discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchBar:)];
 }
@@ -150,8 +152,8 @@
 }
 
 - (void)__baz {
-    
-    [self match:ALT_TOKEN_KIND_BAZ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ALT_TOKEN_KIND_BAZ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchBaz:)];
 }

--- a/test/CSSParser.m
+++ b/test/CSSParser.m
@@ -1,5 +1,6 @@
 #import "CSSParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface CSSParser ()
@@ -221,15 +222,16 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self stylesheet_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf stylesheet_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__stylesheet {
-    
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
     PKTokenizer *t = self.tokenizer;
 
@@ -273,8 +275,8 @@
 	[t.delimitState addStartMarker:@"URL(" endMarker:@")" allowedCharacterSet:nil];
 
     }];
-    while ([self speculate:^{ [self ruleset_]; }]) {
-        [self ruleset_]; 
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf ruleset_];}]) {
+        [PKParser_weakSelf ruleset_];
     }
 
 }
@@ -284,11 +286,11 @@
 }
 
 - (void)__ruleset {
-    
-    [self selectors_]; 
-    [self openCurly_]; 
-    [self decls_]; 
-    [self closeCurly_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf selectors_];
+    [PKParser_weakSelf openCurly_];
+    [PKParser_weakSelf decls_];
+    [PKParser_weakSelf closeCurly_];
 
 }
 
@@ -297,10 +299,10 @@
 }
 
 - (void)__selectors {
-    
-    [self selector_]; 
-    while ([self speculate:^{ [self commaSelector_]; }]) {
-        [self commaSelector_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf selector_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf commaSelector_];}]) {
+        [PKParser_weakSelf commaSelector_];
     }
 
 }
@@ -310,32 +312,32 @@
 }
 
 - (void)__selector {
-    
+    PKParser_weakSelfDecl;
     do {
-        if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-            [self selectorWord_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_HASH, 0]) {
-            [self hash_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_DOT, 0]) {
-            [self dot_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_COLON, 0]) {
-            [self colon_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_GT, 0]) {
-            [self gt_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_OPENBRACKET, 0]) {
-            [self openBracket_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_CLOSEBRACKET, 0]) {
-            [self closeBracket_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_EQ, 0]) {
-            [self eq_]; 
-        } else if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-            [self selectorQuotedString_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_TILDE, 0]) {
-            [self tilde_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_PIPE, 0]) {
-            [self pipe_]; 
+        if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+            [PKParser_weakSelf selectorWord_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_HASH, 0]) {
+            [PKParser_weakSelf hash_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_DOT, 0]) {
+            [PKParser_weakSelf dot_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_COLON, 0]) {
+            [PKParser_weakSelf colon_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_GT, 0]) {
+            [PKParser_weakSelf gt_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_OPENBRACKET, 0]) {
+            [PKParser_weakSelf openBracket_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_CLOSEBRACKET, 0]) {
+            [PKParser_weakSelf closeBracket_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_EQ, 0]) {
+            [PKParser_weakSelf eq_];
+        } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+            [PKParser_weakSelf selectorQuotedString_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_TILDE, 0]) {
+            [PKParser_weakSelf tilde_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_PIPE, 0]) {
+            [PKParser_weakSelf pipe_];
         } else {
-            [self raise:@"No viable alternative found in rule 'selector'."];
+            [PKParser_weakSelf raise:@"No viable alternative found in rule 'selector'."];
         }
     } while ([self predicts:CSS_TOKEN_KIND_CLOSEBRACKET, CSS_TOKEN_KIND_COLON, CSS_TOKEN_KIND_DOT, CSS_TOKEN_KIND_EQ, CSS_TOKEN_KIND_GT, CSS_TOKEN_KIND_HASH, CSS_TOKEN_KIND_OPENBRACKET, CSS_TOKEN_KIND_PIPE, CSS_TOKEN_KIND_TILDE, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]);
 
@@ -346,8 +348,8 @@
 }
 
 - (void)__selectorWord {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchSelectorWord:)];
 }
@@ -357,8 +359,8 @@
 }
 
 - (void)__selectorQuotedString {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchSelectorQuotedString:)];
 }
@@ -368,9 +370,9 @@
 }
 
 - (void)__commaSelector {
-    
-    [self comma_]; 
-    [self selector_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf comma_];
+    [PKParser_weakSelf selector_];
 
 }
 
@@ -379,9 +381,9 @@
 }
 
 - (void)__decls {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self actualDecls_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf actualDecls_];
     }
 
 }
@@ -391,10 +393,10 @@
 }
 
 - (void)__actualDecls {
-    
-    [self decl_]; 
-    while ([self speculate:^{ [self decl_]; }]) {
-        [self decl_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf decl_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf decl_];}]) {
+        [PKParser_weakSelf decl_];
     }
 
 }
@@ -404,14 +406,14 @@
 }
 
 - (void)__decl {
-    
-    [self property_]; 
-    [self colon_]; 
-    [self expr_]; 
-    if ([self speculate:^{ [self important_]; }]) {
-        [self important_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf property_];
+    [PKParser_weakSelf colon_];
+    [PKParser_weakSelf expr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf important_];}]) {
+        [PKParser_weakSelf important_];
     }
-    [self semi_]; 
+    [PKParser_weakSelf semi_];
 
 }
 
@@ -420,8 +422,8 @@
 }
 
 - (void)__property {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchProperty:)];
 }
@@ -431,26 +433,26 @@
 }
 
 - (void)__expr {
-    
+    PKParser_weakSelfDecl;
     do {
-        if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-            [self string_]; 
-        } else if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-            [self constant_]; 
-        } else if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
-            [self num_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_URLLOWER, CSS_TOKEN_KIND_URLUPPER, 0]) {
-            [self url_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_OPENPAREN, 0]) {
-            [self openParen_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_CLOSEPAREN, 0]) {
-            [self closeParen_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_COMMA, 0]) {
-            [self comma_]; 
-        } else if ([self predicts:CSS_TOKEN_KIND_FWDSLASH, TOKEN_KIND_BUILTIN_SYMBOL, 0]) {
-            [self nonTerminatingSymbol_]; 
+        if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+            [PKParser_weakSelf string_];
+        } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+            [PKParser_weakSelf constant_];
+        } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
+            [PKParser_weakSelf num_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_URLLOWER, CSS_TOKEN_KIND_URLUPPER, 0]) {
+            [PKParser_weakSelf url_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_OPENPAREN, 0]) {
+            [PKParser_weakSelf openParen_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_CLOSEPAREN, 0]) {
+            [PKParser_weakSelf closeParen_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_COMMA, 0]) {
+            [PKParser_weakSelf comma_];
+        } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_FWDSLASH, TOKEN_KIND_BUILTIN_SYMBOL, 0]) {
+            [PKParser_weakSelf nonTerminatingSymbol_];
         } else {
-            [self raise:@"No viable alternative found in rule 'expr'."];
+            [PKParser_weakSelf raise:@"No viable alternative found in rule 'expr'."];
         }
     } while ([self predicts:CSS_TOKEN_KIND_CLOSEPAREN, CSS_TOKEN_KIND_COMMA, CSS_TOKEN_KIND_FWDSLASH, CSS_TOKEN_KIND_OPENPAREN, CSS_TOKEN_KIND_URLLOWER, CSS_TOKEN_KIND_URLUPPER, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_SYMBOL, TOKEN_KIND_BUILTIN_WORD, 0]);
 
@@ -461,13 +463,13 @@
 }
 
 - (void)__url {
-    
-    if ([self predicts:CSS_TOKEN_KIND_URLLOWER, 0]) {
-        [self urlLower_]; 
-    } else if ([self predicts:CSS_TOKEN_KIND_URLUPPER, 0]) {
-        [self urlUpper_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_URLLOWER, 0]) {
+        [PKParser_weakSelf urlLower_];
+    } else if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_URLUPPER, 0]) {
+        [PKParser_weakSelf urlUpper_];
     } else {
-        [self raise:@"No viable alternative found in rule 'url'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'url'."];
     }
 
 }
@@ -477,7 +479,7 @@
 }
 
 - (void)__urlLower {
-    
+    PKParser_weakSelfDecl;
     [self match:CSS_TOKEN_KIND_URLLOWER discard:NO]; 
 
     [self fireDelegateSelector:@selector(parser:didMatchUrlLower:)];
@@ -488,7 +490,7 @@
 }
 
 - (void)__urlUpper {
-    
+    PKParser_weakSelfDecl;
     [self match:CSS_TOKEN_KIND_URLUPPER discard:NO]; 
 
     [self fireDelegateSelector:@selector(parser:didMatchUrlUpper:)];
@@ -499,14 +501,14 @@
 }
 
 - (void)__nonTerminatingSymbol {
-    
-    if ([self predicts:CSS_TOKEN_KIND_FWDSLASH, 0]) {
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:CSS_TOKEN_KIND_FWDSLASH, 0]) {
         [self testAndThrow:(id)^{ return NE(LS(1), @";") && NE(LS(1), @"!"); }]; 
-        [self fwdSlash_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_SYMBOL, 0]) {
-        [self matchSymbol:NO]; 
+        [PKParser_weakSelf fwdSlash_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_SYMBOL, 0]) {
+        [PKParser_weakSelf matchSymbol:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'nonTerminatingSymbol'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'nonTerminatingSymbol'."];
     }
 
 }
@@ -516,9 +518,9 @@
 }
 
 - (void)__important {
-    
-    [self bang_]; 
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf bang_];
+    [PKParser_weakSelf matchWord:NO];
 
 }
 
@@ -527,8 +529,8 @@
 }
 
 - (void)__string {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchString:)];
 }
@@ -538,8 +540,8 @@
 }
 
 - (void)__constant {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchConstant:)];
 }
@@ -549,8 +551,8 @@
 }
 
 - (void)__openCurly {
-    
-    [self match:CSS_TOKEN_KIND_OPENCURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_OPENCURLY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOpenCurly:)];
 }
@@ -560,8 +562,8 @@
 }
 
 - (void)__closeCurly {
-    
-    [self match:CSS_TOKEN_KIND_CLOSECURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_CLOSECURLY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchCloseCurly:)];
 }
@@ -571,8 +573,8 @@
 }
 
 - (void)__openBracket {
-    
-    [self match:CSS_TOKEN_KIND_OPENBRACKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_OPENBRACKET discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOpenBracket:)];
 }
@@ -582,8 +584,8 @@
 }
 
 - (void)__closeBracket {
-    
-    [self match:CSS_TOKEN_KIND_CLOSEBRACKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_CLOSEBRACKET discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchCloseBracket:)];
 }
@@ -593,8 +595,8 @@
 }
 
 - (void)__eq {
-    
-    [self match:CSS_TOKEN_KIND_EQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_EQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchEq:)];
 }
@@ -604,8 +606,8 @@
 }
 
 - (void)__comma {
-    
-    [self match:CSS_TOKEN_KIND_COMMA discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_COMMA discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchComma:)];
 }
@@ -615,8 +617,8 @@
 }
 
 - (void)__colon {
-    
-    [self match:CSS_TOKEN_KIND_COLON discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_COLON discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchColon:)];
 }
@@ -626,8 +628,8 @@
 }
 
 - (void)__semi {
-    
-    [self match:CSS_TOKEN_KIND_SEMI discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_SEMI discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchSemi:)];
 }
@@ -637,8 +639,8 @@
 }
 
 - (void)__openParen {
-    
-    [self match:CSS_TOKEN_KIND_OPENPAREN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_OPENPAREN discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOpenParen:)];
 }
@@ -648,8 +650,8 @@
 }
 
 - (void)__closeParen {
-    
-    [self match:CSS_TOKEN_KIND_CLOSEPAREN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_CLOSEPAREN discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchCloseParen:)];
 }
@@ -659,8 +661,8 @@
 }
 
 - (void)__gt {
-    
-    [self match:CSS_TOKEN_KIND_GT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_GT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchGt:)];
 }
@@ -670,8 +672,8 @@
 }
 
 - (void)__tilde {
-    
-    [self match:CSS_TOKEN_KIND_TILDE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_TILDE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTilde:)];
 }
@@ -681,8 +683,8 @@
 }
 
 - (void)__pipe {
-    
-    [self match:CSS_TOKEN_KIND_PIPE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_PIPE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchPipe:)];
 }
@@ -692,8 +694,8 @@
 }
 
 - (void)__fwdSlash {
-    
-    [self match:CSS_TOKEN_KIND_FWDSLASH discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_FWDSLASH discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchFwdSlash:)];
 }
@@ -703,8 +705,8 @@
 }
 
 - (void)__hash {
-    
-    [self match:CSS_TOKEN_KIND_HASH discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_HASH discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchHash:)];
 }
@@ -714,8 +716,8 @@
 }
 
 - (void)__dot {
-    
-    [self match:CSS_TOKEN_KIND_DOT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_DOT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDot:)];
 }
@@ -725,8 +727,8 @@
 }
 
 - (void)__at {
-    
-    [self match:CSS_TOKEN_KIND_AT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_AT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchAt:)];
 }
@@ -736,8 +738,8 @@
 }
 
 - (void)__bang {
-    
-    [self match:CSS_TOKEN_KIND_BANG discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CSS_TOKEN_KIND_BANG discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchBang:)];
 }
@@ -747,8 +749,8 @@
 }
 
 - (void)__num {
-    
-    [self matchNumber:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNum:)];
 }

--- a/test/CreateTableStmtParser.m
+++ b/test/CreateTableStmtParser.m
@@ -1,5 +1,6 @@
 #import "CreateTableStmtParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface CreateTableStmtParser ()
@@ -42,21 +43,22 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self createTableStmt_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf createTableStmt_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)createTableStmt_ {
-    
-    [self match:CREATETABLESTMT_TOKEN_KIND_CREATE discard:YES]; 
-    [self tempOpt_]; 
-    [self match:CREATETABLESTMT_TOKEN_KIND_TABLE discard:YES]; 
-    [self existsOpt_]; 
-    [self databaseName_]; 
-    [self match:CREATETABLESTMT_TOKEN_KIND_SEMI_COLON discard:YES]; 
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CREATETABLESTMT_TOKEN_KIND_CREATE discard:YES];
+    [PKParser_weakSelf tempOpt_];
+    [PKParser_weakSelf match:CREATETABLESTMT_TOKEN_KIND_TABLE discard:YES];
+    [PKParser_weakSelf existsOpt_];
+    [PKParser_weakSelf databaseName_];
+    [PKParser_weakSelf match:CREATETABLESTMT_TOKEN_KIND_SEMI_COLON discard:YES];
+    [PKParser_weakSelf execute:^{
     
 	// NSString *dbName = POP();
 	// BOOL ifNotExists = POP_BOOL();
@@ -71,9 +73,9 @@
 }
 
 - (void)databaseName_ {
-    
-    [self matchQuotedString:NO]; 
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
+    [PKParser_weakSelf execute:^{
     
 	// pop the string value of the `PKToken` on the top of the stack
 	NSString *dbName = POP_STR();
@@ -88,21 +90,21 @@
 }
 
 - (void)tempOpt_ {
-    
-    if ([self predicts:CREATETABLESTMT_TOKEN_KIND_TEMP, CREATETABLESTMT_TOKEN_KIND_TEMPORARY, 0]) {
-        if ([self predicts:CREATETABLESTMT_TOKEN_KIND_TEMP, 0]) {
-            [self match:CREATETABLESTMT_TOKEN_KIND_TEMP discard:YES]; 
-        } else if ([self predicts:CREATETABLESTMT_TOKEN_KIND_TEMPORARY, 0]) {
-            [self match:CREATETABLESTMT_TOKEN_KIND_TEMPORARY discard:YES]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:CREATETABLESTMT_TOKEN_KIND_TEMP, CREATETABLESTMT_TOKEN_KIND_TEMPORARY, 0]) {
+        if ([PKParser_weakSelf predicts:CREATETABLESTMT_TOKEN_KIND_TEMP, 0]) {
+            [PKParser_weakSelf match:CREATETABLESTMT_TOKEN_KIND_TEMP discard:YES];
+        } else if ([PKParser_weakSelf predicts:CREATETABLESTMT_TOKEN_KIND_TEMPORARY, 0]) {
+            [PKParser_weakSelf match:CREATETABLESTMT_TOKEN_KIND_TEMPORARY discard:YES];
         } else {
-            [self raise:@"No viable alternative found in rule 'tempOpt'."];
+            [PKParser_weakSelf raise:@"No viable alternative found in rule 'tempOpt'."];
         }
-        [self execute:^{
+        [PKParser_weakSelf execute:^{
          PUSH(@YES); 
         }];
     } else {
-        [self matchEmpty:NO]; 
-        [self execute:^{
+        [PKParser_weakSelf matchEmpty:NO];
+        [PKParser_weakSelf execute:^{
          PUSH(@NO); 
         }];
     }
@@ -111,17 +113,17 @@
 }
 
 - (void)existsOpt_ {
-    
-    if ([self predicts:CREATETABLESTMT_TOKEN_KIND_IF, 0]) {
-        [self match:CREATETABLESTMT_TOKEN_KIND_IF discard:YES]; 
-        [self match:CREATETABLESTMT_TOKEN_KIND_NOT_UPPER discard:YES]; 
-        [self match:CREATETABLESTMT_TOKEN_KIND_EXISTS discard:YES]; 
-        [self execute:^{
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:CREATETABLESTMT_TOKEN_KIND_IF, 0]) {
+        [PKParser_weakSelf match:CREATETABLESTMT_TOKEN_KIND_IF discard:YES];
+        [PKParser_weakSelf match:CREATETABLESTMT_TOKEN_KIND_NOT_UPPER discard:YES];
+        [PKParser_weakSelf match:CREATETABLESTMT_TOKEN_KIND_EXISTS discard:YES];
+        [PKParser_weakSelf execute:^{
          PUSH(@YES); 
         }];
     } else {
-        [self matchEmpty:NO]; 
-        [self execute:^{
+        [PKParser_weakSelf matchEmpty:NO];
+        [PKParser_weakSelf execute:^{
          PUSH(@NO); 
         }];
     }

--- a/test/CrockfordParser.m
+++ b/test/CrockfordParser.m
@@ -1,5 +1,6 @@
 #import "CrockfordParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface CrockfordParser ()
@@ -124,10 +125,11 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
         [self tryAndRecover:TOKEN_KIND_BUILTIN_EOF block:^{
-            [self program_]; 
-            [self matchEOF:YES]; 
+            [PKParser_weakSelf program_];
+            [PKParser_weakSelf matchEOF:YES];
         } completion:^{
             [self matchEOF:YES];
         }];
@@ -135,8 +137,8 @@
 }
 
 - (void)program_ {
-    
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
         PKTokenizer *t = self.tokenizer;
         
@@ -184,723 +186,723 @@
         [t.delimitState addStartMarker:@"/" endMarker:@"/" allowedCharacterSet:cs];
 
     }];
-    [self stmts_]; 
+    [PKParser_weakSelf stmts_];
 
     [self fireDelegateSelector:@selector(parser:didMatchProgram:)];
 }
 
 - (void)arrayLiteral_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_OPEN_BRACKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_BRACKET discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_BRACKET block:^{ 
-        if ([self speculate:^{ [self expr_]; while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self expr_]; }]) {[self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self expr_]; }}]) {
-            [self expr_]; 
-            while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self expr_]; }]) {
-                [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; 
-                [self expr_]; 
+        if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf expr_];while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf expr_];}]) {[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf expr_];}}]) {
+            [PKParser_weakSelf expr_];
+            while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf expr_];}]) {
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];
+                [PKParser_weakSelf expr_];
             }
         }
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_BRACKET discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_BRACKET discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_BRACKET discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_BRACKET discard:NO];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchArrayLiteral:)];
 }
 
 - (void)block_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_OPEN_CURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_CURLY discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_CURLY block:^{ 
-        if ([self speculate:^{ [self stmts_]; }]) {
-            [self stmts_]; 
+        if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf stmts_];}]) {
+            [PKParser_weakSelf stmts_];
         }
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchBlock:)];
 }
 
 - (void)breakStmt_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_BREAK discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_BREAK discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ 
         if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-            [self name_]; 
+            [PKParser_weakSelf name_];
         }
-        [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchBreakStmt:)];
 }
 
 - (void)caseClause_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self match:CROCKFORD_TOKEN_KIND_CASE discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CASE discard:NO];
         [self tryAndRecover:CROCKFORD_TOKEN_KIND_COLON block:^{ 
-            [self expr_]; 
-            [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; 
+            [PKParser_weakSelf expr_];
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];
         } completion:^{ 
-            [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; 
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];
         }];
-    } while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_CASE discard:NO]; [self tryAndRecover:CROCKFORD_TOKEN_KIND_COLON block:^{ [self expr_]; [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; } completion:^{ [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; }];}]);
-    [self stmts_]; 
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CASE discard:NO];[self tryAndRecover:CROCKFORD_TOKEN_KIND_COLON block:^{ [PKParser_weakSelf expr_];[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];} completion:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];}];}]);
+    [PKParser_weakSelf stmts_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCaseClause:)];
 }
 
 - (void)disruptiveStmt_ {
-    
-    if ([self predicts:CROCKFORD_TOKEN_KIND_BREAK, 0]) {
-        [self breakStmt_]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_RETURN, 0]) {
-        [self returnStmt_]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_THROW, 0]) {
-        [self throwStmt_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_BREAK, 0]) {
+        [PKParser_weakSelf breakStmt_];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_RETURN, 0]) {
+        [PKParser_weakSelf returnStmt_];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_THROW, 0]) {
+        [PKParser_weakSelf throwStmt_];
     } else {
-        [self raise:@"No viable alternative found in rule 'disruptiveStmt'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'disruptiveStmt'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchDisruptiveStmt:)];
 }
 
 - (void)doStmt_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_DO discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_DO discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_WHILE block:^{ 
-        [self block_]; 
-        [self match:CROCKFORD_TOKEN_KIND_WHILE discard:NO]; 
+        [PKParser_weakSelf block_];
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_WHILE discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_WHILE discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_WHILE discard:NO];
     }];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_OPEN_PAREN block:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     }];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_PAREN block:^{ 
-        [self expr_]; 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     }];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchDoStmt:)];
 }
 
 - (void)escapedChar_ {
-    
-    [self matchSymbol:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchSymbol:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchEscapedChar:)];
 }
 
 - (void)exponent_ {
-    
-    [self matchNumber:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchExponent:)];
 }
 
 - (void)expr_ {
-    
-    if ([self predicts:CROCKFORD_TOKEN_KIND_FUNCTION, CROCKFORD_TOKEN_KIND_OPEN_BRACKET, CROCKFORD_TOKEN_KIND_OPEN_CURLY, CROCKFORD_TOKEN_KIND_REGEXBODY, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self literal_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self name_]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_OPEN_PAREN, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_FUNCTION, CROCKFORD_TOKEN_KIND_OPEN_BRACKET, CROCKFORD_TOKEN_KIND_OPEN_CURLY, CROCKFORD_TOKEN_KIND_REGEXBODY, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf literal_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf name_];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_OPEN_PAREN, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
         [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_PAREN block:^{ 
-            [self expr_]; 
-            [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+            [PKParser_weakSelf expr_];
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
         } completion:^{ 
-            [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
         }];
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_BANG, CROCKFORD_TOKEN_KIND_TYPEOF, 0]) {
-        [self prefixOp_]; 
-        [self expr_]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_NEW, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_NEW discard:NO]; 
-        [self expr_]; 
-        [self invocation_]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_DELETE, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_DELETE discard:NO]; 
-        [self expr_]; 
-        [self refinement_]; 
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_BANG, CROCKFORD_TOKEN_KIND_TYPEOF, 0]) {
+        [PKParser_weakSelf prefixOp_];
+        [PKParser_weakSelf expr_];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_NEW, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_NEW discard:NO];
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf invocation_];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_DELETE, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_DELETE discard:NO];
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf refinement_];
     } else {
-        [self raise:@"No viable alternative found in rule 'expr'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'expr'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchExpr:)];
 }
 
 - (void)exprStmt_ {
-    
-    if ([self speculate:^{ do {[self tryAndRecover:CROCKFORD_TOKEN_KIND_EQUALS block:^{ [self name_]; while ([self speculate:^{ [self refinement_]; }]) {[self refinement_]; }[self match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO]; } completion:^{ [self match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO]; }];} while ([self speculate:^{ [self tryAndRecover:CROCKFORD_TOKEN_KIND_EQUALS block:^{ [self name_]; while ([self speculate:^{ [self refinement_]; }]) {[self refinement_]; }[self match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO]; } completion:^{ [self match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO]; }];}]);[self expr_]; }]) {
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ do {[self tryAndRecover:CROCKFORD_TOKEN_KIND_EQUALS block:^{ [PKParser_weakSelf name_];while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf refinement_];}]) {[PKParser_weakSelf refinement_];}[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO];} completion:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO];}];} while ([PKParser_weakSelf speculate:^{ [self tryAndRecover:CROCKFORD_TOKEN_KIND_EQUALS block:^{ [PKParser_weakSelf name_];while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf refinement_];}]) {[PKParser_weakSelf refinement_];}[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO];} completion:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO];}];}]);[PKParser_weakSelf expr_];}]) {
         do {
             [self tryAndRecover:CROCKFORD_TOKEN_KIND_EQUALS block:^{ 
-                [self name_]; 
-                while ([self speculate:^{ [self refinement_]; }]) {
-                    [self refinement_]; 
+                [PKParser_weakSelf name_];
+                while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf refinement_];}]) {
+                    [PKParser_weakSelf refinement_];
                 }
-                [self match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO]; 
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO];
             } completion:^{ 
-                [self match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO]; 
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO];
             }];
-        } while ([self speculate:^{ [self tryAndRecover:CROCKFORD_TOKEN_KIND_EQUALS block:^{ [self name_]; while ([self speculate:^{ [self refinement_]; }]) {[self refinement_]; }[self match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO]; } completion:^{ [self match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO]; }];}]);
-        [self expr_]; 
-    } else if ([self speculate:^{ [self name_]; while ([self speculate:^{ [self refinement_]; }]) {[self refinement_]; }if ([self predicts:CROCKFORD_TOKEN_KIND_PLUS_EQUALS, 0]) {[self match:CROCKFORD_TOKEN_KIND_PLUS_EQUALS discard:NO]; } else if ([self predicts:CROCKFORD_TOKEN_KIND_MINUS_EQUALS, 0]) {[self match:CROCKFORD_TOKEN_KIND_MINUS_EQUALS discard:NO]; } else {[self raise:@"No viable alternative found in rule 'exprStmt'."];}[self expr_]; }]) {
-        [self name_]; 
-        while ([self speculate:^{ [self refinement_]; }]) {
-            [self refinement_]; 
+        } while ([PKParser_weakSelf speculate:^{ [self tryAndRecover:CROCKFORD_TOKEN_KIND_EQUALS block:^{ [PKParser_weakSelf name_];while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf refinement_];}]) {[PKParser_weakSelf refinement_];}[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO];} completion:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO];}];}]);
+        [PKParser_weakSelf expr_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf name_];while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf refinement_];}]) {[PKParser_weakSelf refinement_];}if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_PLUS_EQUALS, 0]) {[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_PLUS_EQUALS discard:NO];} else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_MINUS_EQUALS, 0]) {[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_MINUS_EQUALS discard:NO];} else {[PKParser_weakSelf raise:@"No viable alternative found in rule 'exprStmt'."];}[PKParser_weakSelf expr_];}]) {
+        [PKParser_weakSelf name_];
+        while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf refinement_];}]) {
+            [PKParser_weakSelf refinement_];
         }
-        if ([self predicts:CROCKFORD_TOKEN_KIND_PLUS_EQUALS, 0]) {
-            [self match:CROCKFORD_TOKEN_KIND_PLUS_EQUALS discard:NO]; 
-        } else if ([self predicts:CROCKFORD_TOKEN_KIND_MINUS_EQUALS, 0]) {
-            [self match:CROCKFORD_TOKEN_KIND_MINUS_EQUALS discard:NO]; 
+        if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_PLUS_EQUALS, 0]) {
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_PLUS_EQUALS discard:NO];
+        } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_MINUS_EQUALS, 0]) {
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_MINUS_EQUALS discard:NO];
         } else {
-            [self raise:@"No viable alternative found in rule 'exprStmt'."];
+            [PKParser_weakSelf raise:@"No viable alternative found in rule 'exprStmt'."];
         }
-        [self expr_]; 
-    } else if ([self speculate:^{ [self name_]; while ([self speculate:^{ [self refinement_]; }]) {[self refinement_]; }do {[self invocation_]; } while ([self speculate:^{ [self invocation_]; }]);}]) {
-        [self name_]; 
-        while ([self speculate:^{ [self refinement_]; }]) {
-            [self refinement_]; 
+        [PKParser_weakSelf expr_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf name_];while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf refinement_];}]) {[PKParser_weakSelf refinement_];}do {[PKParser_weakSelf invocation_];} while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf invocation_];}]);}]) {
+        [PKParser_weakSelf name_];
+        while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf refinement_];}]) {
+            [PKParser_weakSelf refinement_];
         }
         do {
-            [self invocation_]; 
-        } while ([self speculate:^{ [self invocation_]; }]);
-    } else if ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_DELETE discard:NO]; [self expr_]; [self refinement_]; }]) {
-        [self match:CROCKFORD_TOKEN_KIND_DELETE discard:NO]; 
-        [self expr_]; 
-        [self refinement_]; 
+            [PKParser_weakSelf invocation_];
+        } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf invocation_];}]);
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_DELETE discard:NO];[PKParser_weakSelf expr_];[PKParser_weakSelf refinement_];}]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_DELETE discard:NO];
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf refinement_];
     } else {
-        [self raise:@"No viable alternative found in rule 'exprStmt'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'exprStmt'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchExprStmt:)];
 }
 
 - (void)forStmt_ {
-    
-    if ([self predicts:CROCKFORD_TOKEN_KIND_FOR, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_FOR discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_FOR, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_FOR discard:NO];
         [self tryAndRecover:CROCKFORD_TOKEN_KIND_OPEN_PAREN block:^{ 
-            [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
         } completion:^{ 
-            [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
         }];
             [self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ 
-                if ([self speculate:^{ [self exprStmt_]; }]) {
-                    [self exprStmt_]; 
+                if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf exprStmt_];}]) {
+                    [PKParser_weakSelf exprStmt_];
                 }
-                [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
             } completion:^{ 
-                [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
             }];
             [self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ 
-                if ([self speculate:^{ [self expr_]; }]) {
-                    [self expr_]; 
+                if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf expr_];}]) {
+                    [PKParser_weakSelf expr_];
                 }
-                [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
             } completion:^{ 
-                [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
             }];
-                if ([self speculate:^{ [self exprStmt_]; }]) {
-                    [self exprStmt_]; 
+                if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf exprStmt_];}]) {
+                    [PKParser_weakSelf exprStmt_];
                 }
-            } else if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+            } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
                     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_PAREN block:^{ 
                     [self tryAndRecover:CROCKFORD_TOKEN_KIND_IN block:^{ 
-                        [self name_]; 
-                        [self match:CROCKFORD_TOKEN_KIND_IN discard:NO]; 
+                        [PKParser_weakSelf name_];
+                        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_IN discard:NO];
                     } completion:^{ 
-                        [self match:CROCKFORD_TOKEN_KIND_IN discard:NO]; 
+                        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_IN discard:NO];
                     }];
-                        [self expr_]; 
-                        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+                        [PKParser_weakSelf expr_];
+                        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
                     } completion:^{ 
-                        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+                        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
                     }];
-                        [self block_]; 
+                        [PKParser_weakSelf block_];
                     } else {
-                        [self raise:@"No viable alternative found in rule 'forStmt'."];
+                        [PKParser_weakSelf raise:@"No viable alternative found in rule 'forStmt'."];
                     }
 
     [self fireDelegateSelector:@selector(parser:didMatchForStmt:)];
 }
 
 - (void)fraction_ {
-    
-    [self matchNumber:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchFraction:)];
 }
 
 - (void)function_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_FUNCTION discard:NO]; 
-    [self name_]; 
-    [self parameters_]; 
-    [self functionBody_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_FUNCTION discard:NO];
+    [PKParser_weakSelf name_];
+    [PKParser_weakSelf parameters_];
+    [PKParser_weakSelf functionBody_];
 
     [self fireDelegateSelector:@selector(parser:didMatchFunction:)];
 }
 
 - (void)functionBody_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_OPEN_CURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_CURLY discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_CURLY block:^{ 
-        [self stmts_]; 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO]; 
+        [PKParser_weakSelf stmts_];
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchFunctionBody:)];
 }
 
 - (void)functionLiteral_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_FUNCTION discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_FUNCTION discard:NO];
     if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self name_]; 
+        [PKParser_weakSelf name_];
     }
-    [self parameters_]; 
-    [self functionBody_]; 
+    [PKParser_weakSelf parameters_];
+    [PKParser_weakSelf functionBody_];
 
     [self fireDelegateSelector:@selector(parser:didMatchFunctionLiteral:)];
 }
 
 - (void)ifStmt_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_IF discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_IF discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_OPEN_PAREN block:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     }];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_PAREN block:^{ 
-        [self expr_]; 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     }];
-        [self block_]; 
-        if ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_ELSE discard:NO]; if ([self speculate:^{ [self ifStmt_]; }]) {[self ifStmt_]; }[self block_]; }]) {
-            [self match:CROCKFORD_TOKEN_KIND_ELSE discard:NO]; 
-            if ([self speculate:^{ [self ifStmt_]; }]) {
-                [self ifStmt_]; 
+        [PKParser_weakSelf block_];
+        if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_ELSE discard:NO];if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf ifStmt_];}]) {[PKParser_weakSelf ifStmt_];}[PKParser_weakSelf block_];}]) {
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_ELSE discard:NO];
+            if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf ifStmt_];}]) {
+                [PKParser_weakSelf ifStmt_];
             }
-            [self block_]; 
+            [PKParser_weakSelf block_];
         }
 
     [self fireDelegateSelector:@selector(parser:didMatchIfStmt:)];
 }
 
 - (void)infixOp_ {
-    
-    if ([self predicts:CROCKFORD_TOKEN_KIND_STAR, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_STAR discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_FORWARD_SLASH, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_FORWARD_SLASH discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_PERCENT, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_PERCENT discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_PLUS, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_PLUS discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_MINUS, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_MINUS discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_GE_SYM, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_GE_SYM discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_LE_SYM, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_LE_SYM discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_GT_SYM, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_GT_SYM discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_LT_SYM, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_LT_SYM discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_TRIPLE_EQUALS, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_TRIPLE_EQUALS discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_DOUBLE_NOT_EQUAL, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_DOUBLE_NOT_EQUAL discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_DOUBLE_PIPE, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_DOUBLE_PIPE discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_DOUBLE_AMPERSAND, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_DOUBLE_AMPERSAND discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_STAR, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_STAR discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_FORWARD_SLASH, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_FORWARD_SLASH discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_PERCENT, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_PERCENT discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_PLUS, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_PLUS discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_MINUS, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_MINUS discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_GE_SYM, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_GE_SYM discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_LE_SYM, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_LE_SYM discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_GT_SYM, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_GT_SYM discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_LT_SYM, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_LT_SYM discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_TRIPLE_EQUALS, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_TRIPLE_EQUALS discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_DOUBLE_NOT_EQUAL, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_DOUBLE_NOT_EQUAL discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_DOUBLE_PIPE, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_DOUBLE_PIPE discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_DOUBLE_AMPERSAND, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_DOUBLE_AMPERSAND discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'infixOp'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'infixOp'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchInfixOp:)];
 }
 
 - (void)integer_ {
-    
-    [self matchNumber:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchInteger:)];
 }
 
 - (void)invocation_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_PAREN block:^{ 
-        if ([self speculate:^{ [self expr_]; while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self expr_]; }]) {[self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self expr_]; }}]) {
-            [self expr_]; 
-            while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self expr_]; }]) {
-                [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; 
-                [self expr_]; 
+        if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf expr_];while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf expr_];}]) {[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf expr_];}}]) {
+            [PKParser_weakSelf expr_];
+            while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf expr_];}]) {
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];
+                [PKParser_weakSelf expr_];
             }
         }
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchInvocation:)];
 }
 
 - (void)literal_ {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
-        [self numberLiteral_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self stringLiteral_]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_OPEN_CURLY, 0]) {
-        [self objectLiteral_]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_OPEN_BRACKET, 0]) {
-        [self arrayLiteral_]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_FUNCTION, 0]) {
-        [self functionLiteral_]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_REGEXBODY, 0]) {
-        [self regexLiteral_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
+        [PKParser_weakSelf numberLiteral_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf stringLiteral_];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_OPEN_CURLY, 0]) {
+        [PKParser_weakSelf objectLiteral_];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_OPEN_BRACKET, 0]) {
+        [PKParser_weakSelf arrayLiteral_];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_FUNCTION, 0]) {
+        [PKParser_weakSelf functionLiteral_];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_REGEXBODY, 0]) {
+        [PKParser_weakSelf regexLiteral_];
     } else {
-        [self raise:@"No viable alternative found in rule 'literal'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'literal'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchLiteral:)];
 }
 
 - (void)name_ {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchName:)];
 }
 
 - (void)numberLiteral_ {
-    
-    [self matchNumber:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNumberLiteral:)];
 }
 
 - (void)objectLiteral_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_OPEN_CURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_CURLY discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_CURLY block:^{ 
-        if ([self speculate:^{ [self nameValPair_]; while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self nameValPair_]; }]) {[self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self nameValPair_]; }}]) {
-            [self nameValPair_]; 
-            while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self nameValPair_]; }]) {
-                [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; 
-                [self nameValPair_]; 
+        if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf nameValPair_];while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf nameValPair_];}]) {[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf nameValPair_];}}]) {
+            [PKParser_weakSelf nameValPair_];
+            while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf nameValPair_];}]) {
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];
+                [PKParser_weakSelf nameValPair_];
             }
         }
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchObjectLiteral:)];
 }
 
 - (void)nameValPair_ {
-    
+    PKParser_weakSelfDecl;
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_COLON block:^{ 
-        if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-            [self name_]; 
-        } else if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-            [self stringLiteral_]; 
+        if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+            [PKParser_weakSelf name_];
+        } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+            [PKParser_weakSelf stringLiteral_];
         } else {
-            [self raise:@"No viable alternative found in rule 'nameValPair'."];
+            [PKParser_weakSelf raise:@"No viable alternative found in rule 'nameValPair'."];
         }
-        [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];
     }];
-        [self expr_]; 
+        [PKParser_weakSelf expr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchNameValPair:)];
 }
 
 - (void)parameters_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_PAREN block:^{ 
-        if ([self speculate:^{ [self name_]; while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self name_]; }]) {[self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self name_]; }}]) {
-            [self name_]; 
-            while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self name_]; }]) {
-                [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; 
-                [self name_]; 
+        if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf name_];while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf name_];}]) {[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf name_];}}]) {
+            [PKParser_weakSelf name_];
+            while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf name_];}]) {
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];
+                [PKParser_weakSelf name_];
             }
         }
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchParameters:)];
 }
 
 - (void)prefixOp_ {
-    
-    if ([self predicts:CROCKFORD_TOKEN_KIND_TYPEOF, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_TYPEOF discard:NO]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_BANG, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_BANG discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_TYPEOF, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_TYPEOF discard:NO];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_BANG, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_BANG discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'prefixOp'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'prefixOp'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchPrefixOp:)];
 }
 
 - (void)refinement_ {
-    
-    if ([self predicts:CROCKFORD_TOKEN_KIND_DOT, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_DOT discard:NO]; 
-        [self name_]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_OPEN_BRACKET, 0]) {
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_BRACKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_DOT, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_DOT discard:NO];
+        [PKParser_weakSelf name_];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_OPEN_BRACKET, 0]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_BRACKET discard:NO];
         [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_BRACKET block:^{ 
-            [self expr_]; 
-            [self match:CROCKFORD_TOKEN_KIND_CLOSE_BRACKET discard:NO]; 
+            [PKParser_weakSelf expr_];
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_BRACKET discard:NO];
         } completion:^{ 
-            [self match:CROCKFORD_TOKEN_KIND_CLOSE_BRACKET discard:NO]; 
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_BRACKET discard:NO];
         }];
     } else {
-        [self raise:@"No viable alternative found in rule 'refinement'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'refinement'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchRefinement:)];
 }
 
 - (void)regexLiteral_ {
-    
-    [self regexBody_]; 
-    if ([self speculate:^{ [self regexMods_]; }]) {
-        [self regexMods_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf regexBody_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf regexMods_];}]) {
+        [PKParser_weakSelf regexMods_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchRegexLiteral:)];
 }
 
 - (void)regexBody_ {
-    
+    PKParser_weakSelfDecl;
     [self match:CROCKFORD_TOKEN_KIND_REGEXBODY discard:NO]; 
 
     [self fireDelegateSelector:@selector(parser:didMatchRegexBody:)];
 }
 
 - (void)regexMods_ {
-    
+    PKParser_weakSelfDecl;
     [self testAndThrow:(id)^{ return MATCHES_IGNORE_CASE(@"[imxs]+", LS(1)); }]; 
-    [self matchWord:NO]; 
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchRegexMods:)];
 }
 
 - (void)returnStmt_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_RETURN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_RETURN discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ 
-        if ([self speculate:^{ [self expr_]; }]) {
-            [self expr_]; 
+        if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf expr_];}]) {
+            [PKParser_weakSelf expr_];
         }
-        [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchReturnStmt:)];
 }
 
 - (void)stmts_ {
-    
-    while ([self speculate:^{ [self stmt_]; }]) {
-        [self stmt_]; 
+    PKParser_weakSelfDecl;
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf stmt_];}]) {
+        [PKParser_weakSelf stmt_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchStmts:)];
 }
 
 - (void)stmt_ {
-    
-    if ([self predicts:CROCKFORD_TOKEN_KIND_VAR, 0]) {
-        [self varStmt_]; 
-    } else if ([self predicts:CROCKFORD_TOKEN_KIND_FUNCTION, 0]) {
-        [self function_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self nonFunction_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_VAR, 0]) {
+        [PKParser_weakSelf varStmt_];
+    } else if ([PKParser_weakSelf predicts:CROCKFORD_TOKEN_KIND_FUNCTION, 0]) {
+        [PKParser_weakSelf function_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf nonFunction_];
     } else {
-        [self raise:@"No viable alternative found in rule 'stmt'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'stmt'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchStmt:)];
 }
 
 - (void)nonFunction_ {
-    
-    if ([self speculate:^{ [self tryAndRecover:CROCKFORD_TOKEN_KIND_COLON block:^{ [self name_]; [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; } completion:^{ [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; }];}]) {
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [self tryAndRecover:CROCKFORD_TOKEN_KIND_COLON block:^{ [PKParser_weakSelf name_];[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];} completion:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];}];}]) {
         [self tryAndRecover:CROCKFORD_TOKEN_KIND_COLON block:^{ 
-            [self name_]; 
-            [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; 
+            [PKParser_weakSelf name_];
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];
         } completion:^{ 
-            [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; 
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];
         }];
     }
-    if ([self speculate:^{ [self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ [self exprStmt_]; [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; } completion:^{ [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; }];}]) {
+    if ([PKParser_weakSelf speculate:^{ [self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ [PKParser_weakSelf exprStmt_];[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];} completion:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];}];}]) {
         [self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ 
-            [self exprStmt_]; 
-            [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+            [PKParser_weakSelf exprStmt_];
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
         } completion:^{ 
-            [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
         }];
-    } else if ([self speculate:^{ [self disruptiveStmt_]; }]) {
-        [self disruptiveStmt_]; 
-    } else if ([self speculate:^{ [self tryStmt_]; }]) {
-        [self tryStmt_]; 
-    } else if ([self speculate:^{ [self ifStmt_]; }]) {
-        [self ifStmt_]; 
-    } else if ([self speculate:^{ [self switchStmt_]; }]) {
-        [self switchStmt_]; 
-    } else if ([self speculate:^{ [self whileStmt_]; }]) {
-        [self whileStmt_]; 
-    } else if ([self speculate:^{ [self forStmt_]; }]) {
-        [self forStmt_]; 
-    } else if ([self speculate:^{ [self doStmt_]; }]) {
-        [self doStmt_]; 
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf disruptiveStmt_];}]) {
+        [PKParser_weakSelf disruptiveStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf tryStmt_];}]) {
+        [PKParser_weakSelf tryStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf ifStmt_];}]) {
+        [PKParser_weakSelf ifStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf switchStmt_];}]) {
+        [PKParser_weakSelf switchStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf whileStmt_];}]) {
+        [PKParser_weakSelf whileStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf forStmt_];}]) {
+        [PKParser_weakSelf forStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf doStmt_];}]) {
+        [PKParser_weakSelf doStmt_];
     } else {
-        [self raise:@"No viable alternative found in rule 'nonFunction'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'nonFunction'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchNonFunction:)];
 }
 
 - (void)stringLiteral_ {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchStringLiteral:)];
 }
 
 - (void)switchStmt_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_SWITCH discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SWITCH discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_OPEN_PAREN block:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     }];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_PAREN block:^{ 
-        [self expr_]; 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     }];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_OPEN_CURLY block:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_CURLY discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_CURLY discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_CURLY discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_CURLY discard:NO];
     }];
             [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_CURLY block:^{ 
         do {
-            [self caseClause_]; 
-            if ([self speculate:^{ [self disruptiveStmt_]; }]) {
-                [self disruptiveStmt_]; 
+            [PKParser_weakSelf caseClause_];
+            if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf disruptiveStmt_];}]) {
+                [PKParser_weakSelf disruptiveStmt_];
             }
-        } while ([self speculate:^{ [self caseClause_]; if ([self speculate:^{ [self disruptiveStmt_]; }]) {[self disruptiveStmt_]; }}]);
-                if ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_DEFAULT discard:NO]; [self tryAndRecover:CROCKFORD_TOKEN_KIND_COLON block:^{ [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; } completion:^{ [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; }];[self stmts_]; }]) {
-                [self match:CROCKFORD_TOKEN_KIND_DEFAULT discard:NO]; 
+        } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf caseClause_];if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf disruptiveStmt_];}]) {[PKParser_weakSelf disruptiveStmt_];}}]);
+                if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_DEFAULT discard:NO];[self tryAndRecover:CROCKFORD_TOKEN_KIND_COLON block:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];} completion:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];}];[PKParser_weakSelf stmts_];}]) {
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_DEFAULT discard:NO];
                 [self tryAndRecover:CROCKFORD_TOKEN_KIND_COLON block:^{ 
-                    [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; 
+                    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];
                 } completion:^{ 
-                    [self match:CROCKFORD_TOKEN_KIND_COLON discard:NO]; 
+                    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COLON discard:NO];
                 }];
-                    [self stmts_]; 
+                    [PKParser_weakSelf stmts_];
                 }
-                [self match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO]; 
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO];
             } completion:^{ 
-                [self match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO]; 
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_CURLY discard:NO];
             }];
 
     [self fireDelegateSelector:@selector(parser:didMatchSwitchStmt:)];
 }
 
 - (void)throwStmt_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_THROW discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_THROW discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ 
-        [self expr_]; 
-        [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchThrowStmt:)];
 }
 
 - (void)tryStmt_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_TRY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_TRY discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CATCH block:^{ 
-        [self block_]; 
-        [self match:CROCKFORD_TOKEN_KIND_CATCH discard:NO]; 
+        [PKParser_weakSelf block_];
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CATCH discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CATCH discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CATCH discard:NO];
     }];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_OPEN_PAREN block:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     }];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_PAREN block:^{ 
-        [self name_]; 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf name_];
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     }];
-        [self block_]; 
-        if ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_FINALLY discard:NO]; [self block_]; }]) {
-            [self match:CROCKFORD_TOKEN_KIND_FINALLY discard:NO]; 
-            [self block_]; 
+        [PKParser_weakSelf block_];
+        if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_FINALLY discard:NO];[PKParser_weakSelf block_];}]) {
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_FINALLY discard:NO];
+            [PKParser_weakSelf block_];
         }
 
     [self fireDelegateSelector:@selector(parser:didMatchTryStmt:)];
 }
 
 - (void)varStmt_ {
-    
-    while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_VAR discard:NO]; [self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ [self nameExprPair_]; while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self nameExprPair_]; }]) {[self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self nameExprPair_]; }[self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; } completion:^{ [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; }];}]) {
-        [self match:CROCKFORD_TOKEN_KIND_VAR discard:NO]; 
+    PKParser_weakSelfDecl;
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_VAR discard:NO];[self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ [PKParser_weakSelf nameExprPair_];while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf nameExprPair_];}]) {[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf nameExprPair_];}[PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];} completion:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];}];}]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_VAR discard:NO];
         [self tryAndRecover:CROCKFORD_TOKEN_KIND_SEMI_COLON block:^{ 
-            [self nameExprPair_]; 
-            while ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; [self nameExprPair_]; }]) {
-                [self match:CROCKFORD_TOKEN_KIND_COMMA discard:NO]; 
-                [self nameExprPair_]; 
+            [PKParser_weakSelf nameExprPair_];
+            while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf nameExprPair_];}]) {
+                [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_COMMA discard:NO];
+                [PKParser_weakSelf nameExprPair_];
             }
-            [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
         } completion:^{ 
-            [self match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO]; 
+            [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_SEMI_COLON discard:NO];
         }];
     }
 
@@ -908,31 +910,31 @@
 }
 
 - (void)nameExprPair_ {
-    
-    [self name_]; 
-    if ([self speculate:^{ [self match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO]; [self expr_]; }]) {
-        [self match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO]; 
-        [self expr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf name_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO];[PKParser_weakSelf expr_];}]) {
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_EQUALS discard:NO];
+        [PKParser_weakSelf expr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchNameExprPair:)];
 }
 
 - (void)whileStmt_ {
-    
-    [self match:CROCKFORD_TOKEN_KIND_WHILE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_WHILE discard:NO];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_OPEN_PAREN block:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_OPEN_PAREN discard:NO];
     }];
     [self tryAndRecover:CROCKFORD_TOKEN_KIND_CLOSE_PAREN block:^{ 
-        [self expr_]; 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     } completion:^{ 
-        [self match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf match:CROCKFORD_TOKEN_KIND_CLOSE_PAREN discard:NO];
     }];
-        [self block_]; 
+        [PKParser_weakSelf block_];
 
     [self fireDelegateSelector:@selector(parser:didMatchWhileStmt:)];
 }

--- a/test/CurlyActionParser.m
+++ b/test/CurlyActionParser.m
@@ -1,5 +1,6 @@
 #import "CurlyActionParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface CurlyActionParser ()
@@ -26,18 +27,19 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)start_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self matchWord:NO]; 
+        [PKParser_weakSelf matchWord:NO];
     } while ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]);
-    [self execute:^{
+    [PKParser_weakSelf execute:^{
     
     id word = nil;
     while (!EMPTY()) {

--- a/test/DelimitedParser.m
+++ b/test/DelimitedParser.m
@@ -1,5 +1,6 @@
 #import "DelimitedParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface DelimitedParser ()
@@ -39,15 +40,16 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__start {
-    
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
     PKTokenizer *t = self.tokenizer;
 
@@ -55,7 +57,7 @@
     [t setTokenizerState:t.delimitState from:'<' to:'<'];
 
     }];
-    [self s_]; 
+    [PKParser_weakSelf s_];
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
@@ -65,7 +67,7 @@
 }
 
 - (void)__s {
-    
+    PKParser_weakSelfDecl;
     [self match:DELIMITED_TOKEN_KIND_S discard:NO]; 
 
     [self fireDelegateSelector:@selector(parser:didMatchS:)];

--- a/test/DeterministicPalindromeParser.m
+++ b/test/DeterministicPalindromeParser.m
@@ -1,5 +1,6 @@
 #import "DeterministicPalindromeParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface DeterministicPalindromeParser ()
@@ -32,26 +33,27 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self s_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf s_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)s_ {
-    
-    if ([self predicts:DETERMINISTICPALINDROME_TOKEN_KIND_0, 0]) {
-        [self match:DETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO]; 
-        [self s_]; 
-        [self match:DETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO]; 
-    } else if ([self predicts:DETERMINISTICPALINDROME_TOKEN_KIND_1, 0]) {
-        [self match:DETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO]; 
-        [self s_]; 
-        [self match:DETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO]; 
-    } else if ([self predicts:DETERMINISTICPALINDROME_TOKEN_KIND_2, 0]) {
-        [self match:DETERMINISTICPALINDROME_TOKEN_KIND_2 discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:DETERMINISTICPALINDROME_TOKEN_KIND_0, 0]) {
+        [PKParser_weakSelf match:DETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO];
+        [PKParser_weakSelf s_];
+        [PKParser_weakSelf match:DETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO];
+    } else if ([PKParser_weakSelf predicts:DETERMINISTICPALINDROME_TOKEN_KIND_1, 0]) {
+        [PKParser_weakSelf match:DETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO];
+        [PKParser_weakSelf s_];
+        [PKParser_weakSelf match:DETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO];
+    } else if ([PKParser_weakSelf predicts:DETERMINISTICPALINDROME_TOKEN_KIND_2, 0]) {
+        [PKParser_weakSelf match:DETERMINISTICPALINDROME_TOKEN_KIND_2 discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 's'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 's'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchS:)];

--- a/test/DotQuestionParser.m
+++ b/test/DotQuestionParser.m
@@ -1,5 +1,6 @@
 #import "DotQuestionParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface DotQuestionParser ()
@@ -39,19 +40,20 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__start {
-    
-    [self a_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf a_];
     if ([self predicts:TOKEN_KIND_BUILTIN_ANY, 0]) {
-        [self matchAny:NO]; 
+        [PKParser_weakSelf matchAny:NO];
     }
-    [self a_]; 
+    [PKParser_weakSelf a_];
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
@@ -61,8 +63,8 @@
 }
 
 - (void)__a {
-    
-    [self match:DOTQUESTION_TOKEN_KIND_A discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:DOTQUESTION_TOKEN_KIND_A discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchA:)];
 }

--- a/test/DreadedParser.m
+++ b/test/DreadedParser.m
@@ -1,5 +1,6 @@
 #import "DreadedParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface DreadedParser ()
@@ -45,21 +46,22 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self s_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf s_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__s {
-    
-    if ([self speculate:^{ [self a_]; }]) {
-        [self a_]; 
-    } else if ([self speculate:^{ [self a_]; [self b_]; }]) {
-        [self a_]; 
-        [self b_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf a_];}]) {
+        [PKParser_weakSelf a_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf a_];[PKParser_weakSelf b_];}]) {
+        [PKParser_weakSelf a_];
+        [PKParser_weakSelf b_];
     } else {
-        [self raise:@"No viable alternative found in rule 's'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 's'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchS:)];
@@ -70,8 +72,8 @@
 }
 
 - (void)__a {
-    
-    [self match:DREADED_TOKEN_KIND_A discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:DREADED_TOKEN_KIND_A discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchA:)];
 }
@@ -81,8 +83,8 @@
 }
 
 - (void)__b {
-    
-    [self match:DREADED_TOKEN_KIND_B discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:DREADED_TOKEN_KIND_B discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchB:)];
 }

--- a/test/DupeLiteralsParser.m
+++ b/test/DupeLiteralsParser.m
@@ -1,5 +1,6 @@
 #import "DupeLiteralsParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface DupeLiteralsParser ()
@@ -36,7 +37,8 @@
 }
 
 - (void)start {
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
     PKTokenizer *t = self.tokenizer;
 
@@ -44,57 +46,57 @@
 
     }];
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)start_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        if ([self predicts:DUPELITERALS_TOKEN_KIND_NONE, DUPELITERALS_TOKEN_KIND_NONE_1, DUPELITERALS_TOKEN_KIND_NONE_2, 0]) {
-            [self none_]; 
-        } else if ([self predicts:DUPELITERALS_TOKEN_KIND_QUOTE, 0]) {
-            [self quote_]; 
-        } else if ([self predicts:DUPELITERALS_TOKEN_KIND_PIPE, 0]) {
-            [self block_]; 
+        if ([PKParser_weakSelf predicts:DUPELITERALS_TOKEN_KIND_NONE, DUPELITERALS_TOKEN_KIND_NONE_1, DUPELITERALS_TOKEN_KIND_NONE_2, 0]) {
+            [PKParser_weakSelf none_];
+        } else if ([PKParser_weakSelf predicts:DUPELITERALS_TOKEN_KIND_QUOTE, 0]) {
+            [PKParser_weakSelf quote_];
+        } else if ([PKParser_weakSelf predicts:DUPELITERALS_TOKEN_KIND_PIPE, 0]) {
+            [PKParser_weakSelf block_];
         } else {
-            [self raise:@"No viable alternative found in rule 'start'."];
+            [PKParser_weakSelf raise:@"No viable alternative found in rule 'start'."];
         }
-    } while ([self speculate:^{ if ([self predicts:DUPELITERALS_TOKEN_KIND_NONE, DUPELITERALS_TOKEN_KIND_NONE_1, DUPELITERALS_TOKEN_KIND_NONE_2, 0]) {[self none_]; } else if ([self predicts:DUPELITERALS_TOKEN_KIND_QUOTE, 0]) {[self quote_]; } else if ([self predicts:DUPELITERALS_TOKEN_KIND_PIPE, 0]) {[self block_]; } else {[self raise:@"No viable alternative found in rule 'start'."];}}]);
+    } while ([PKParser_weakSelf speculate:^{ if ([PKParser_weakSelf predicts:DUPELITERALS_TOKEN_KIND_NONE, DUPELITERALS_TOKEN_KIND_NONE_1, DUPELITERALS_TOKEN_KIND_NONE_2, 0]) {[PKParser_weakSelf none_];} else if ([PKParser_weakSelf predicts:DUPELITERALS_TOKEN_KIND_QUOTE, 0]) {[PKParser_weakSelf quote_];} else if ([PKParser_weakSelf predicts:DUPELITERALS_TOKEN_KIND_PIPE, 0]) {[PKParser_weakSelf block_];} else {[PKParser_weakSelf raise:@"No viable alternative found in rule 'start'."];}}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
 
 - (void)none_ {
-    
-    if ([self predicts:DUPELITERALS_TOKEN_KIND_NONE, 0]) {
-        [self match:DUPELITERALS_TOKEN_KIND_NONE discard:NO]; 
-    } else if ([self predicts:DUPELITERALS_TOKEN_KIND_NONE_1, 0]) {
-        [self match:DUPELITERALS_TOKEN_KIND_NONE_1 discard:NO]; 
-    } else if ([self predicts:DUPELITERALS_TOKEN_KIND_NONE_2, 0]) {
-        [self match:DUPELITERALS_TOKEN_KIND_NONE_2 discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:DUPELITERALS_TOKEN_KIND_NONE, 0]) {
+        [PKParser_weakSelf match:DUPELITERALS_TOKEN_KIND_NONE discard:NO];
+    } else if ([PKParser_weakSelf predicts:DUPELITERALS_TOKEN_KIND_NONE_1, 0]) {
+        [PKParser_weakSelf match:DUPELITERALS_TOKEN_KIND_NONE_1 discard:NO];
+    } else if ([PKParser_weakSelf predicts:DUPELITERALS_TOKEN_KIND_NONE_2, 0]) {
+        [PKParser_weakSelf match:DUPELITERALS_TOKEN_KIND_NONE_2 discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'none'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'none'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchNone:)];
 }
 
 - (void)quote_ {
-    
-    [self match:DUPELITERALS_TOKEN_KIND_QUOTE discard:YES]; 
-    [self matchWord:NO]; 
-    [self match:DUPELITERALS_TOKEN_KIND_QUOTE discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:DUPELITERALS_TOKEN_KIND_QUOTE discard:YES];
+    [PKParser_weakSelf matchWord:NO];
+    [PKParser_weakSelf match:DUPELITERALS_TOKEN_KIND_QUOTE discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchQuote:)];
 }
 
 - (void)block_ {
-    
-    [self match:DUPELITERALS_TOKEN_KIND_PIPE discard:NO]; 
-    [self matchWord:NO]; 
-    [self match:DUPELITERALS_TOKEN_KIND_PIPE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:DUPELITERALS_TOKEN_KIND_PIPE discard:NO];
+    [PKParser_weakSelf matchWord:NO];
+    [PKParser_weakSelf match:DUPELITERALS_TOKEN_KIND_PIPE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchBlock:)];
 }

--- a/test/ElementAssignParser.m
+++ b/test/ElementAssignParser.m
@@ -1,5 +1,6 @@
 #import "ElementAssignParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface ElementAssignParser ()
@@ -40,10 +41,11 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
     [self tryAndRecover:TOKEN_KIND_BUILTIN_EOF block:^{
-        [self start_]; 
-        [self matchEOF:YES]; 
+        [PKParser_weakSelf start_];
+        [PKParser_weakSelf matchEOF:YES];
     } completion:^{
         [self matchEOF:YES];
     }];
@@ -51,125 +53,125 @@
 }
 
 - (void)start_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self stat_]; 
-    } while ([self speculate:^{ [self stat_]; }]);
+        [PKParser_weakSelf stat_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf stat_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
 
 - (void)stat_ {
-    
-    if ([self speculate:^{ [self tryAndRecover:ELEMENTASSIGN_TOKEN_KIND_DOT block:^{ [self assign_]; [self dot_]; } completion:^{ [self dot_]; }];}]) {
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [self tryAndRecover:ELEMENTASSIGN_TOKEN_KIND_DOT block:^{ [PKParser_weakSelf assign_];[PKParser_weakSelf dot_];} completion:^{ [PKParser_weakSelf dot_];}];}]) {
         [self tryAndRecover:ELEMENTASSIGN_TOKEN_KIND_DOT block:^{ 
-            [self assign_]; 
-            [self dot_]; 
+            [PKParser_weakSelf assign_];
+            [PKParser_weakSelf dot_];
         } completion:^{ 
-            [self dot_]; 
+            [PKParser_weakSelf dot_];
         }];
-    } else if ([self speculate:^{ [self tryAndRecover:ELEMENTASSIGN_TOKEN_KIND_SEMI block:^{ [self list_]; [self semi_]; } completion:^{ [self semi_]; }];}]) {
+    } else if ([PKParser_weakSelf speculate:^{ [self tryAndRecover:ELEMENTASSIGN_TOKEN_KIND_SEMI block:^{ [PKParser_weakSelf list_];[PKParser_weakSelf semi_];} completion:^{ [PKParser_weakSelf semi_];}];}]) {
         [self tryAndRecover:ELEMENTASSIGN_TOKEN_KIND_SEMI block:^{ 
-            [self list_]; 
-            [self semi_]; 
+            [PKParser_weakSelf list_];
+            [PKParser_weakSelf semi_];
         } completion:^{ 
-            [self semi_]; 
+            [PKParser_weakSelf semi_];
         }];
     } else {
-        [self raise:@"No viable alternative found in rule 'stat'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'stat'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchStat:)];
 }
 
 - (void)assign_ {
-    
+    PKParser_weakSelfDecl;
     [self tryAndRecover:ELEMENTASSIGN_TOKEN_KIND_EQ block:^{ 
-        [self list_]; 
-        [self eq_]; 
+        [PKParser_weakSelf list_];
+        [PKParser_weakSelf eq_];
     } completion:^{ 
-        [self eq_]; 
+        [PKParser_weakSelf eq_];
     }];
-        [self list_]; 
+        [PKParser_weakSelf list_];
 
     [self fireDelegateSelector:@selector(parser:didMatchAssign:)];
 }
 
 - (void)list_ {
-    
-    [self lbracket_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf lbracket_];
     [self tryAndRecover:ELEMENTASSIGN_TOKEN_KIND_RBRACKET block:^{ 
-        [self elements_]; 
-        [self rbracket_]; 
+        [PKParser_weakSelf elements_];
+        [PKParser_weakSelf rbracket_];
     } completion:^{ 
-        [self rbracket_]; 
+        [PKParser_weakSelf rbracket_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchList:)];
 }
 
 - (void)elements_ {
-    
-    [self element_]; 
-    while ([self speculate:^{ [self comma_]; [self element_]; }]) {
-        [self comma_]; 
-        [self element_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf element_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf comma_];[PKParser_weakSelf element_];}]) {
+        [PKParser_weakSelf comma_];
+        [PKParser_weakSelf element_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchElements:)];
 }
 
 - (void)element_ {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
-        [self matchNumber:NO]; 
-    } else if ([self predicts:ELEMENTASSIGN_TOKEN_KIND_LBRACKET, 0]) {
-        [self list_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
+        [PKParser_weakSelf matchNumber:NO];
+    } else if ([PKParser_weakSelf predicts:ELEMENTASSIGN_TOKEN_KIND_LBRACKET, 0]) {
+        [PKParser_weakSelf list_];
     } else {
-        [self raise:@"No viable alternative found in rule 'element'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'element'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchElement:)];
 }
 
 - (void)lbracket_ {
-    
-    [self match:ELEMENTASSIGN_TOKEN_KIND_LBRACKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ELEMENTASSIGN_TOKEN_KIND_LBRACKET discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLbracket:)];
 }
 
 - (void)rbracket_ {
-    
-    [self match:ELEMENTASSIGN_TOKEN_KIND_RBRACKET discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ELEMENTASSIGN_TOKEN_KIND_RBRACKET discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchRbracket:)];
 }
 
 - (void)comma_ {
-    
-    [self match:ELEMENTASSIGN_TOKEN_KIND_COMMA discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ELEMENTASSIGN_TOKEN_KIND_COMMA discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchComma:)];
 }
 
 - (void)eq_ {
-    
-    [self match:ELEMENTASSIGN_TOKEN_KIND_EQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ELEMENTASSIGN_TOKEN_KIND_EQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchEq:)];
 }
 
 - (void)dot_ {
-    
-    [self match:ELEMENTASSIGN_TOKEN_KIND_DOT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ELEMENTASSIGN_TOKEN_KIND_DOT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDot:)];
 }
 
 - (void)semi_ {
-    
-    [self match:ELEMENTASSIGN_TOKEN_KIND_SEMI discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ELEMENTASSIGN_TOKEN_KIND_SEMI discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchSemi:)];
 }

--- a/test/ElementParser.m
+++ b/test/ElementParser.m
@@ -1,5 +1,6 @@
 #import "ElementParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface ElementParser ()
@@ -63,17 +64,18 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self lists_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf lists_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__lists {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self list_]; 
-    } while ([self speculate:^{ [self list_]; }]);
+        [PKParser_weakSelf list_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf list_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchLists:)];
 }
@@ -83,10 +85,10 @@
 }
 
 - (void)__list {
-    
-    [self lbracket_]; 
-    [self elements_]; 
-    [self rbracket_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf lbracket_];
+    [PKParser_weakSelf elements_];
+    [PKParser_weakSelf rbracket_];
 
     [self fireDelegateSelector:@selector(parser:didMatchList:)];
 }
@@ -96,11 +98,11 @@
 }
 
 - (void)__elements {
-    
-    [self element_]; 
-    while ([self speculate:^{ [self comma_]; [self element_]; }]) {
-        [self comma_]; 
-        [self element_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf element_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf comma_];[PKParser_weakSelf element_];}]) {
+        [PKParser_weakSelf comma_];
+        [PKParser_weakSelf element_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchElements:)];
@@ -111,13 +113,13 @@
 }
 
 - (void)__element {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
-        [self matchNumber:NO]; 
-    } else if ([self predicts:ELEMENT_TOKEN_KIND_LBRACKET, 0]) {
-        [self list_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
+        [PKParser_weakSelf matchNumber:NO];
+    } else if ([PKParser_weakSelf predicts:ELEMENT_TOKEN_KIND_LBRACKET, 0]) {
+        [PKParser_weakSelf list_];
     } else {
-        [self raise:@"No viable alternative found in rule 'element'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'element'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchElement:)];
@@ -128,8 +130,8 @@
 }
 
 - (void)__lbracket {
-    
-    [self match:ELEMENT_TOKEN_KIND_LBRACKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ELEMENT_TOKEN_KIND_LBRACKET discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLbracket:)];
 }
@@ -139,8 +141,8 @@
 }
 
 - (void)__rbracket {
-    
-    [self match:ELEMENT_TOKEN_KIND_RBRACKET discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ELEMENT_TOKEN_KIND_RBRACKET discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchRbracket:)];
 }
@@ -150,8 +152,8 @@
 }
 
 - (void)__comma {
-    
-    [self match:ELEMENT_TOKEN_KIND_COMMA discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:ELEMENT_TOKEN_KIND_COMMA discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchComma:)];
 }

--- a/test/ExpressionActionsParser.m
+++ b/test/ExpressionActionsParser.m
@@ -1,5 +1,6 @@
 #import "ExpressionActionsParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface ExpressionActionsParser ()
@@ -129,15 +130,16 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self expr_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf expr_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__expr {
-    
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
     PKTokenizer *t = self.tokenizer;
     [t.symbolState add:@"!="];
@@ -145,7 +147,7 @@
     [t.symbolState add:@">="];
 
     }];
-    [self orExpr_]; 
+    [PKParser_weakSelf orExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchExpr:)];
 }
@@ -155,10 +157,10 @@
 }
 
 - (void)__orExpr {
-    
-    [self andExpr_]; 
-    while ([self speculate:^{ [self orTerm_]; }]) {
-        [self orTerm_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf andExpr_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf orTerm_];}]) {
+        [PKParser_weakSelf orTerm_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchOrExpr:)];
@@ -169,10 +171,10 @@
 }
 
 - (void)__orTerm {
-    
-    [self match:EXPRESSIONACTIONS_TOKEN_KIND_OR discard:YES]; 
-    [self andExpr_]; 
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_OR discard:YES];
+    [PKParser_weakSelf andExpr_];
+    [PKParser_weakSelf execute:^{
     
 	BOOL rhs = POP_BOOL();
 	BOOL lhs = POP_BOOL();
@@ -188,10 +190,10 @@
 }
 
 - (void)__andExpr {
-    
-    [self relExpr_]; 
-    while ([self speculate:^{ [self andTerm_]; }]) {
-        [self andTerm_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf relExpr_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf andTerm_];}]) {
+        [PKParser_weakSelf andTerm_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAndExpr:)];
@@ -202,10 +204,10 @@
 }
 
 - (void)__andTerm {
-    
-    [self match:EXPRESSIONACTIONS_TOKEN_KIND_AND discard:YES]; 
-    [self relExpr_]; 
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_AND discard:YES];
+    [PKParser_weakSelf relExpr_];
+    [PKParser_weakSelf execute:^{
     
 	BOOL rhs = POP_BOOL();
 	BOOL lhs = POP_BOOL();
@@ -221,10 +223,10 @@
 }
 
 - (void)__relExpr {
-    
-    [self callExpr_]; 
-    while ([self speculate:^{ [self relOpTerm_]; }]) {
-        [self relOpTerm_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf callExpr_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf relOpTerm_];}]) {
+        [PKParser_weakSelf relOpTerm_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchRelExpr:)];
@@ -235,21 +237,21 @@
 }
 
 - (void)__relOp {
-    
-    if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_LT_SYM, 0]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_LT_SYM discard:NO]; 
-    } else if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_GT_SYM, 0]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_GT_SYM discard:NO]; 
-    } else if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_EQUALS, 0]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_EQUALS discard:NO]; 
-    } else if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_NOT_EQUAL, 0]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_NOT_EQUAL discard:NO]; 
-    } else if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_LE_SYM, 0]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_LE_SYM discard:NO]; 
-    } else if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_GE_SYM, 0]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_GE_SYM discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_LT_SYM, 0]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_LT_SYM discard:NO];
+    } else if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_GT_SYM, 0]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_GT_SYM discard:NO];
+    } else if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_EQUALS, 0]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_EQUALS discard:NO];
+    } else if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_NOT_EQUAL, 0]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_NOT_EQUAL discard:NO];
+    } else if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_LE_SYM, 0]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_LE_SYM discard:NO];
+    } else if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_GE_SYM, 0]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_GE_SYM discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'relOp'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'relOp'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchRelOp:)];
@@ -260,10 +262,10 @@
 }
 
 - (void)__relOpTerm {
-    
-    [self relOp_]; 
-    [self callExpr_]; 
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf relOp_];
+    [PKParser_weakSelf callExpr_];
+    [PKParser_weakSelf execute:^{
     
 	NSInteger rhs = POP_INT();
 	NSString  *op = POP_STR();
@@ -286,14 +288,14 @@
 }
 
 - (void)__callExpr {
-    
-    [self primary_]; 
-    if ([self speculate:^{ [self match:EXPRESSIONACTIONS_TOKEN_KIND_OPEN_PAREN discard:NO]; if ([self speculate:^{ [self argList_]; }]) {[self argList_]; }[self match:EXPRESSIONACTIONS_TOKEN_KIND_CLOSE_PAREN discard:NO]; }]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_OPEN_PAREN discard:NO]; 
-        if ([self speculate:^{ [self argList_]; }]) {
-            [self argList_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf primary_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_OPEN_PAREN discard:NO];if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf argList_];}]) {[PKParser_weakSelf argList_];}[PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_CLOSE_PAREN discard:NO];}]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_OPEN_PAREN discard:NO];
+        if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf argList_];}]) {
+            [PKParser_weakSelf argList_];
         }
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_CLOSE_PAREN discard:NO];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchCallExpr:)];
@@ -304,11 +306,11 @@
 }
 
 - (void)__argList {
-    
-    [self atom_]; 
-    while ([self speculate:^{ [self match:EXPRESSIONACTIONS_TOKEN_KIND_COMMA discard:NO]; [self atom_]; }]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_COMMA discard:NO]; 
-        [self atom_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf atom_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf atom_];}]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_COMMA discard:NO];
+        [PKParser_weakSelf atom_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchArgList:)];
@@ -319,15 +321,15 @@
 }
 
 - (void)__primary {
-    
-    if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_NO, EXPRESSIONACTIONS_TOKEN_KIND_NO_UPPER, EXPRESSIONACTIONS_TOKEN_KIND_YES, EXPRESSIONACTIONS_TOKEN_KIND_YES_UPPER, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self atom_]; 
-    } else if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_OPEN_PAREN, 0]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_OPEN_PAREN discard:NO]; 
-        [self expr_]; 
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_NO, EXPRESSIONACTIONS_TOKEN_KIND_NO_UPPER, EXPRESSIONACTIONS_TOKEN_KIND_YES, EXPRESSIONACTIONS_TOKEN_KIND_YES_UPPER, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf atom_];
+    } else if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_OPEN_PAREN, 0]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_OPEN_PAREN discard:NO];
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_CLOSE_PAREN discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'primary'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'primary'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchPrimary:)];
@@ -338,13 +340,13 @@
 }
 
 - (void)__atom {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self obj_]; 
-    } else if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_NO, EXPRESSIONACTIONS_TOKEN_KIND_NO_UPPER, EXPRESSIONACTIONS_TOKEN_KIND_YES, EXPRESSIONACTIONS_TOKEN_KIND_YES_UPPER, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self literal_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf obj_];
+    } else if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_NO, EXPRESSIONACTIONS_TOKEN_KIND_NO_UPPER, EXPRESSIONACTIONS_TOKEN_KIND_YES, EXPRESSIONACTIONS_TOKEN_KIND_YES_UPPER, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf literal_];
     } else {
-        [self raise:@"No viable alternative found in rule 'atom'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'atom'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAtom:)];
@@ -355,10 +357,10 @@
 }
 
 - (void)__obj {
-    
-    [self id_]; 
-    while ([self speculate:^{ [self member_]; }]) {
-        [self member_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf id_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf member_];}]) {
+        [PKParser_weakSelf member_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchObj:)];
@@ -369,8 +371,8 @@
 }
 
 - (void)__id {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchId:)];
 }
@@ -380,9 +382,9 @@
 }
 
 - (void)__member {
-    
-    [self match:EXPRESSIONACTIONS_TOKEN_KIND_DOT discard:NO]; 
-    [self id_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_DOT discard:NO];
+    [PKParser_weakSelf id_];
 
     [self fireDelegateSelector:@selector(parser:didMatchMember:)];
 }
@@ -392,25 +394,25 @@
 }
 
 - (void)__literal {
-    
-    if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_NO, EXPRESSIONACTIONS_TOKEN_KIND_NO_UPPER, EXPRESSIONACTIONS_TOKEN_KIND_YES, EXPRESSIONACTIONS_TOKEN_KIND_YES_UPPER, 0]) {
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_NO, EXPRESSIONACTIONS_TOKEN_KIND_NO_UPPER, EXPRESSIONACTIONS_TOKEN_KIND_YES, EXPRESSIONACTIONS_TOKEN_KIND_YES_UPPER, 0]) {
         [self testAndThrow:(id)^{ return LA(1) != EXPRESSIONACTIONS_TOKEN_KIND_YES_UPPER; }]; 
-        [self bool_]; 
-        [self execute:^{
+        [PKParser_weakSelf bool_];
+        [PKParser_weakSelf execute:^{
          PUSH_BOOL(EQ_IGNORE_CASE(POP_STR(), @"yes")); 
         }];
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
-        [self matchNumber:NO]; 
-        [self execute:^{
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
+        [PKParser_weakSelf matchNumber:NO];
+        [PKParser_weakSelf execute:^{
          PUSH_DOUBLE(POP_DOUBLE()); 
         }];
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self matchQuotedString:NO]; 
-        [self execute:^{
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf matchQuotedString:NO];
+        [PKParser_weakSelf execute:^{
          PUSH(POP_STR()); 
         }];
     } else {
-        [self raise:@"No viable alternative found in rule 'literal'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'literal'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchLiteral:)];
@@ -421,18 +423,18 @@
 }
 
 - (void)__bool {
-    
-    if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_YES, 0]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_YES discard:NO]; 
-    } else if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_YES_UPPER, 0]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_YES_UPPER discard:NO]; 
-    } else if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_NO, 0]) {
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_NO discard:NO]; 
-    } else if ([self predicts:EXPRESSIONACTIONS_TOKEN_KIND_NO_UPPER, 0]) {
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_YES, 0]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_YES discard:NO];
+    } else if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_YES_UPPER, 0]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_YES_UPPER discard:NO];
+    } else if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_NO, 0]) {
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_NO discard:NO];
+    } else if ([PKParser_weakSelf predicts:EXPRESSIONACTIONS_TOKEN_KIND_NO_UPPER, 0]) {
         [self testAndThrow:(id)^{ return NE(LS(1), @"NO"); }]; 
-        [self match:EXPRESSIONACTIONS_TOKEN_KIND_NO_UPPER discard:NO]; 
+        [PKParser_weakSelf match:EXPRESSIONACTIONS_TOKEN_KIND_NO_UPPER discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'bool'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'bool'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchBool:)];

--- a/test/ExpressionParser.m
+++ b/test/ExpressionParser.m
@@ -1,5 +1,6 @@
 #import "ExpressionParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface ExpressionParser ()
@@ -177,15 +178,16 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self expr_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf expr_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__expr {
-    
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
     PKTokenizer *t = self.tokenizer;
     [t.symbolState add:@"!="];
@@ -193,7 +195,7 @@
     [t.symbolState add:@">="];
 
     }];
-    [self orExpr_]; 
+    [PKParser_weakSelf orExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchExpr:)];
 }
@@ -203,10 +205,10 @@
 }
 
 - (void)__orExpr {
-    
-    [self andExpr_]; 
-    while ([self speculate:^{ [self orTerm_]; }]) {
-        [self orTerm_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf andExpr_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf orTerm_];}]) {
+        [PKParser_weakSelf orTerm_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchOrExpr:)];
@@ -217,9 +219,9 @@
 }
 
 - (void)__orTerm {
-    
-    [self or_]; 
-    [self andExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf or_];
+    [PKParser_weakSelf andExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchOrTerm:)];
 }
@@ -229,10 +231,10 @@
 }
 
 - (void)__andExpr {
-    
-    [self relExpr_]; 
-    while ([self speculate:^{ [self andTerm_]; }]) {
-        [self andTerm_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf relExpr_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf andTerm_];}]) {
+        [PKParser_weakSelf andTerm_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAndExpr:)];
@@ -243,9 +245,9 @@
 }
 
 - (void)__andTerm {
-    
-    [self and_]; 
-    [self relExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf and_];
+    [PKParser_weakSelf relExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchAndTerm:)];
 }
@@ -255,11 +257,11 @@
 }
 
 - (void)__relExpr {
-    
-    [self callExpr_]; 
-    while ([self speculate:^{ [self relOp_]; [self callExpr_]; }]) {
-        [self relOp_]; 
-        [self callExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf callExpr_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf relOp_];[PKParser_weakSelf callExpr_];}]) {
+        [PKParser_weakSelf relOp_];
+        [PKParser_weakSelf callExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchRelExpr:)];
@@ -270,21 +272,21 @@
 }
 
 - (void)__relOp {
-    
-    if ([self predicts:EXPRESSION_TOKEN_KIND_LT, 0]) {
-        [self lt_]; 
-    } else if ([self predicts:EXPRESSION_TOKEN_KIND_GT, 0]) {
-        [self gt_]; 
-    } else if ([self predicts:EXPRESSION_TOKEN_KIND_EQ, 0]) {
-        [self eq_]; 
-    } else if ([self predicts:EXPRESSION_TOKEN_KIND_NE, 0]) {
-        [self ne_]; 
-    } else if ([self predicts:EXPRESSION_TOKEN_KIND_LE, 0]) {
-        [self le_]; 
-    } else if ([self predicts:EXPRESSION_TOKEN_KIND_GE, 0]) {
-        [self ge_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_LT, 0]) {
+        [PKParser_weakSelf lt_];
+    } else if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_GT, 0]) {
+        [PKParser_weakSelf gt_];
+    } else if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_EQ, 0]) {
+        [PKParser_weakSelf eq_];
+    } else if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_NE, 0]) {
+        [PKParser_weakSelf ne_];
+    } else if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_LE, 0]) {
+        [PKParser_weakSelf le_];
+    } else if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_GE, 0]) {
+        [PKParser_weakSelf ge_];
     } else {
-        [self raise:@"No viable alternative found in rule 'relOp'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'relOp'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchRelOp:)];
@@ -295,14 +297,14 @@
 }
 
 - (void)__callExpr {
-    
-    [self primary_]; 
-    if ([self speculate:^{ [self openParen_]; if ([self speculate:^{ [self argList_]; }]) {[self argList_]; }[self closeParen_]; }]) {
-        [self openParen_]; 
-        if ([self speculate:^{ [self argList_]; }]) {
-            [self argList_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf primary_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf openParen_];if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf argList_];}]) {[PKParser_weakSelf argList_];}[PKParser_weakSelf closeParen_];}]) {
+        [PKParser_weakSelf openParen_];
+        if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf argList_];}]) {
+            [PKParser_weakSelf argList_];
         }
-        [self closeParen_]; 
+        [PKParser_weakSelf closeParen_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchCallExpr:)];
@@ -313,11 +315,11 @@
 }
 
 - (void)__argList {
-    
-    [self atom_]; 
-    while ([self speculate:^{ [self comma_]; [self atom_]; }]) {
-        [self comma_]; 
-        [self atom_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf atom_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf comma_];[PKParser_weakSelf atom_];}]) {
+        [PKParser_weakSelf comma_];
+        [PKParser_weakSelf atom_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchArgList:)];
@@ -328,15 +330,15 @@
 }
 
 - (void)__primary {
-    
-    if ([self predicts:EXPRESSION_TOKEN_KIND_NO, EXPRESSION_TOKEN_KIND_YES, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self atom_]; 
-    } else if ([self predicts:EXPRESSION_TOKEN_KIND_OPENPAREN, 0]) {
-        [self openParen_]; 
-        [self expr_]; 
-        [self closeParen_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_NO, EXPRESSION_TOKEN_KIND_YES, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf atom_];
+    } else if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_OPENPAREN, 0]) {
+        [PKParser_weakSelf openParen_];
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf closeParen_];
     } else {
-        [self raise:@"No viable alternative found in rule 'primary'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'primary'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchPrimary:)];
@@ -347,13 +349,13 @@
 }
 
 - (void)__atom {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self obj_]; 
-    } else if ([self predicts:EXPRESSION_TOKEN_KIND_NO, EXPRESSION_TOKEN_KIND_YES, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self literal_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf obj_];
+    } else if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_NO, EXPRESSION_TOKEN_KIND_YES, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf literal_];
     } else {
-        [self raise:@"No viable alternative found in rule 'atom'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'atom'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAtom:)];
@@ -364,10 +366,10 @@
 }
 
 - (void)__obj {
-    
-    [self id_]; 
-    while ([self speculate:^{ [self member_]; }]) {
-        [self member_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf id_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf member_];}]) {
+        [PKParser_weakSelf member_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchObj:)];
@@ -378,8 +380,8 @@
 }
 
 - (void)__id {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchId:)];
 }
@@ -389,9 +391,9 @@
 }
 
 - (void)__member {
-    
-    [self dot_]; 
-    [self id_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf dot_];
+    [PKParser_weakSelf id_];
 
     [self fireDelegateSelector:@selector(parser:didMatchMember:)];
 }
@@ -401,15 +403,15 @@
 }
 
 - (void)__literal {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self matchQuotedString:NO]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
-        [self matchNumber:NO]; 
-    } else if ([self predicts:EXPRESSION_TOKEN_KIND_NO, EXPRESSION_TOKEN_KIND_YES, 0]) {
-        [self bool_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf matchQuotedString:NO];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
+        [PKParser_weakSelf matchNumber:NO];
+    } else if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_NO, EXPRESSION_TOKEN_KIND_YES, 0]) {
+        [PKParser_weakSelf bool_];
     } else {
-        [self raise:@"No viable alternative found in rule 'literal'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'literal'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchLiteral:)];
@@ -420,13 +422,13 @@
 }
 
 - (void)__bool {
-    
-    if ([self predicts:EXPRESSION_TOKEN_KIND_YES, 0]) {
-        [self yes_]; 
-    } else if ([self predicts:EXPRESSION_TOKEN_KIND_NO, 0]) {
-        [self no_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_YES, 0]) {
+        [PKParser_weakSelf yes_];
+    } else if ([PKParser_weakSelf predicts:EXPRESSION_TOKEN_KIND_NO, 0]) {
+        [PKParser_weakSelf no_];
     } else {
-        [self raise:@"No viable alternative found in rule 'bool'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'bool'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchBool:)];
@@ -437,8 +439,8 @@
 }
 
 - (void)__lt {
-    
-    [self match:EXPRESSION_TOKEN_KIND_LT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_LT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLt:)];
 }
@@ -448,8 +450,8 @@
 }
 
 - (void)__gt {
-    
-    [self match:EXPRESSION_TOKEN_KIND_GT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_GT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchGt:)];
 }
@@ -459,8 +461,8 @@
 }
 
 - (void)__eq {
-    
-    [self match:EXPRESSION_TOKEN_KIND_EQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_EQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchEq:)];
 }
@@ -470,8 +472,8 @@
 }
 
 - (void)__ne {
-    
-    [self match:EXPRESSION_TOKEN_KIND_NE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_NE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNe:)];
 }
@@ -481,8 +483,8 @@
 }
 
 - (void)__le {
-    
-    [self match:EXPRESSION_TOKEN_KIND_LE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_LE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLe:)];
 }
@@ -492,8 +494,8 @@
 }
 
 - (void)__ge {
-    
-    [self match:EXPRESSION_TOKEN_KIND_GE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_GE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchGe:)];
 }
@@ -503,8 +505,8 @@
 }
 
 - (void)__openParen {
-    
-    [self match:EXPRESSION_TOKEN_KIND_OPENPAREN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_OPENPAREN discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOpenParen:)];
 }
@@ -514,8 +516,8 @@
 }
 
 - (void)__closeParen {
-    
-    [self match:EXPRESSION_TOKEN_KIND_CLOSEPAREN discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_CLOSEPAREN discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchCloseParen:)];
 }
@@ -525,8 +527,8 @@
 }
 
 - (void)__yes {
-    
-    [self match:EXPRESSION_TOKEN_KIND_YES discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_YES discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchYes:)];
 }
@@ -536,8 +538,8 @@
 }
 
 - (void)__no {
-    
-    [self match:EXPRESSION_TOKEN_KIND_NO discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_NO discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNo:)];
 }
@@ -547,8 +549,8 @@
 }
 
 - (void)__dot {
-    
-    [self match:EXPRESSION_TOKEN_KIND_DOT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_DOT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDot:)];
 }
@@ -558,8 +560,8 @@
 }
 
 - (void)__comma {
-    
-    [self match:EXPRESSION_TOKEN_KIND_COMMA discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_COMMA discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchComma:)];
 }
@@ -569,8 +571,8 @@
 }
 
 - (void)__or {
-    
-    [self match:EXPRESSION_TOKEN_KIND_OR discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_OR discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOr:)];
 }
@@ -580,8 +582,8 @@
 }
 
 - (void)__and {
-    
-    [self match:EXPRESSION_TOKEN_KIND_AND discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:EXPRESSION_TOKEN_KIND_AND discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchAnd:)];
 }

--- a/test/GrammarActionsParser.m
+++ b/test/GrammarActionsParser.m
@@ -1,5 +1,6 @@
 #import "GrammarActionsParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
     
 #define MY_M 1
 
@@ -41,7 +42,8 @@
 }
 
 - (void)start {
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
     NSAssert([self.foo isEqualToString:@"hello world"], @"");
     NSAssert([_foo isEqualToString:@"hello world"], @"");
@@ -53,10 +55,10 @@
 
     }];
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
-    [self execute:^{
+    [PKParser_weakSelf execute:^{
     
     NSAssert([self.foo isEqualToString:@"goodbye cruel world"], @"");
     NSAssert([_foo isEqualToString:@"goodbye cruel world"], @"");
@@ -69,9 +71,9 @@
 }
 
 - (void)start_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self matchWord:NO]; 
+        [PKParser_weakSelf matchWord:NO];
     } while ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]);
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];

--- a/test/GreedParser.m
+++ b/test/GreedParser.m
@@ -1,5 +1,6 @@
 #import "GreedParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface GreedParser ()
@@ -45,28 +46,29 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__start {
-    
-    if ([self predicts:GREED_TOKEN_KIND_A, 0]) {
-        [self a_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:GREED_TOKEN_KIND_A, 0]) {
+        [PKParser_weakSelf a_];
         while ([self predicts:TOKEN_KIND_BUILTIN_ANY, 0]) {
-            [self matchAny:NO]; 
+            [PKParser_weakSelf matchAny:NO];
         }
-        [self a_]; 
-    } else if ([self predicts:GREED_TOKEN_KIND_B, 0]) {
-        [self b_]; 
+        [PKParser_weakSelf a_];
+    } else if ([PKParser_weakSelf predicts:GREED_TOKEN_KIND_B, 0]) {
+        [PKParser_weakSelf b_];
         do {
-            [self matchAny:NO]; 
+            [PKParser_weakSelf matchAny:NO];
         } while ([self predicts:TOKEN_KIND_BUILTIN_ANY, 0]);
-        [self b_]; 
+        [PKParser_weakSelf b_];
     } else {
-        [self raise:@"No viable alternative found in rule 'start'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'start'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
@@ -77,8 +79,8 @@
 }
 
 - (void)__a {
-    
-    [self match:GREED_TOKEN_KIND_A discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:GREED_TOKEN_KIND_A discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchA:)];
 }
@@ -88,8 +90,8 @@
 }
 
 - (void)__b {
-    
-    [self match:GREED_TOKEN_KIND_B discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:GREED_TOKEN_KIND_B discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchB:)];
 }

--- a/test/GreedyFailureNestedParser.m
+++ b/test/GreedyFailureNestedParser.m
@@ -1,5 +1,6 @@
 #import "GreedyFailureNestedParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface GreedyFailureNestedParser ()
@@ -36,10 +37,11 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
     [self tryAndRecover:TOKEN_KIND_BUILTIN_EOF block:^{
-        [self structs_]; 
-        [self matchEOF:YES]; 
+        [PKParser_weakSelf structs_];
+        [PKParser_weakSelf matchEOF:YES];
     } completion:^{
         [self matchEOF:YES];
     }];
@@ -47,82 +49,82 @@
 }
 
 - (void)structs_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self structure_]; 
-    } while ([self speculate:^{ [self structure_]; }]);
+        [PKParser_weakSelf structure_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf structure_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchStructs:)];
 }
 
 - (void)structure_ {
-    
-    [self lcurly_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf lcurly_];
     [self tryAndRecover:GREEDYFAILURENESTED_TOKEN_KIND_RCURLY block:^{ 
-        [self pair_]; 
-        while ([self speculate:^{ [self comma_]; [self pair_]; }]) {
-            [self comma_]; 
-            [self pair_]; 
+        [PKParser_weakSelf pair_];
+        while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf comma_];[PKParser_weakSelf pair_];}]) {
+            [PKParser_weakSelf comma_];
+            [PKParser_weakSelf pair_];
         }
-        [self rcurly_]; 
+        [PKParser_weakSelf rcurly_];
     } completion:^{ 
-        [self rcurly_]; 
+        [PKParser_weakSelf rcurly_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchStructure:)];
 }
 
 - (void)pair_ {
-    
+    PKParser_weakSelfDecl;
     [self tryAndRecover:GREEDYFAILURENESTED_TOKEN_KIND_COLON block:^{ 
-        [self name_]; 
-        [self colon_]; 
+        [PKParser_weakSelf name_];
+        [PKParser_weakSelf colon_];
     } completion:^{ 
-        [self colon_]; 
+        [PKParser_weakSelf colon_];
     }];
-        [self value_]; 
+        [PKParser_weakSelf value_];
 
     [self fireDelegateSelector:@selector(parser:didMatchPair:)];
 }
 
 - (void)name_ {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchName:)];
 }
 
 - (void)value_ {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchValue:)];
 }
 
 - (void)comma_ {
-    
-    [self match:GREEDYFAILURENESTED_TOKEN_KIND_COMMA discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:GREEDYFAILURENESTED_TOKEN_KIND_COMMA discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchComma:)];
 }
 
 - (void)lcurly_ {
-    
-    [self match:GREEDYFAILURENESTED_TOKEN_KIND_LCURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:GREEDYFAILURENESTED_TOKEN_KIND_LCURLY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLcurly:)];
 }
 
 - (void)rcurly_ {
-    
-    [self match:GREEDYFAILURENESTED_TOKEN_KIND_RCURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:GREEDYFAILURENESTED_TOKEN_KIND_RCURLY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchRcurly:)];
 }
 
 - (void)colon_ {
-    
-    [self match:GREEDYFAILURENESTED_TOKEN_KIND_COLON discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:GREEDYFAILURENESTED_TOKEN_KIND_COLON discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchColon:)];
 }

--- a/test/GreedyFailureParser.m
+++ b/test/GreedyFailureParser.m
@@ -1,5 +1,6 @@
 #import "GreedyFailureParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface GreedyFailureParser ()
@@ -34,10 +35,11 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
     [self tryAndRecover:TOKEN_KIND_BUILTIN_EOF block:^{
-        [self structs_]; 
-        [self matchEOF:YES]; 
+        [PKParser_weakSelf structs_];
+        [PKParser_weakSelf matchEOF:YES];
     } completion:^{
         [self matchEOF:YES];
     }];
@@ -45,64 +47,64 @@
 }
 
 - (void)structs_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self structure_]; 
-    } while ([self speculate:^{ [self structure_]; }]);
+        [PKParser_weakSelf structure_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf structure_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchStructs:)];
 }
 
 - (void)structure_ {
-    
-    [self lcurly_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf lcurly_];
     [self tryAndRecover:GREEDYFAILURE_TOKEN_KIND_COLON block:^{ 
-        [self name_]; 
-        [self colon_]; 
+        [PKParser_weakSelf name_];
+        [PKParser_weakSelf colon_];
     } completion:^{ 
-        [self colon_]; 
+        [PKParser_weakSelf colon_];
     }];
     [self tryAndRecover:GREEDYFAILURE_TOKEN_KIND_RCURLY block:^{ 
-        [self value_]; 
-        [self rcurly_]; 
+        [PKParser_weakSelf value_];
+        [PKParser_weakSelf rcurly_];
     } completion:^{ 
-        [self rcurly_]; 
+        [PKParser_weakSelf rcurly_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchStructure:)];
 }
 
 - (void)name_ {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchName:)];
 }
 
 - (void)value_ {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchValue:)];
 }
 
 - (void)lcurly_ {
-    
-    [self match:GREEDYFAILURE_TOKEN_KIND_LCURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:GREEDYFAILURE_TOKEN_KIND_LCURLY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLcurly:)];
 }
 
 - (void)rcurly_ {
-    
-    [self match:GREEDYFAILURE_TOKEN_KIND_RCURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:GREEDYFAILURE_TOKEN_KIND_RCURLY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchRcurly:)];
 }
 
 - (void)colon_ {
-    
-    [self match:GREEDYFAILURE_TOKEN_KIND_COLON discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:GREEDYFAILURE_TOKEN_KIND_COLON discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchColon:)];
 }

--- a/test/HTMLParser.m
+++ b/test/HTMLParser.m
@@ -1,5 +1,6 @@
 #import "HTMLParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface HTMLParser ()
@@ -157,15 +158,16 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__start {
-    
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
     PKTokenizer *t = self.tokenizer;
 
@@ -195,8 +197,8 @@
     [t.delimitState setFallbackState:t.symbolState from:'<' to:'<'];
 
     }];
-    while ([self speculate:^{ [self anything_]; }]) {
-        [self anything_]; 
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf anything_];}]) {
+        [PKParser_weakSelf anything_];
     }
 
 }
@@ -206,23 +208,23 @@
 }
 
 - (void)__anything {
-    
-    if ([self speculate:^{ [self scriptElement_]; }]) {
-        [self scriptElement_]; 
-    } else if ([self speculate:^{ [self styleElement_]; }]) {
-        [self styleElement_]; 
-    } else if ([self speculate:^{ [self tag_]; }]) {
-        [self tag_]; 
-    } else if ([self speculate:^{ [self procInstr_]; }]) {
-        [self procInstr_]; 
-    } else if ([self speculate:^{ [self comment_]; }]) {
-        [self comment_]; 
-    } else if ([self speculate:^{ [self doctype_]; }]) {
-        [self doctype_]; 
-    } else if ([self speculate:^{ [self text_]; }]) {
-        [self text_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf scriptElement_];}]) {
+        [PKParser_weakSelf scriptElement_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf styleElement_];}]) {
+        [PKParser_weakSelf styleElement_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf tag_];}]) {
+        [PKParser_weakSelf tag_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf procInstr_];}]) {
+        [PKParser_weakSelf procInstr_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf comment_];}]) {
+        [PKParser_weakSelf comment_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf doctype_];}]) {
+        [PKParser_weakSelf doctype_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf text_];}]) {
+        [PKParser_weakSelf text_];
     } else {
-        [self raise:@"No viable alternative found in rule 'anything'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'anything'."];
     }
 
 }
@@ -232,10 +234,10 @@
 }
 
 - (void)__scriptElement {
-    
-    [self scriptStartTag_]; 
-    [self scriptElementContent_]; 
-    [self scriptEndTag_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf scriptStartTag_];
+    [PKParser_weakSelf scriptElementContent_];
+    [PKParser_weakSelf scriptEndTag_];
 
 }
 
@@ -244,13 +246,13 @@
 }
 
 - (void)__scriptStartTag {
-    
-    [self lt_]; 
-    [self scriptTagName_]; 
-    while ([self speculate:^{ [self attr_]; }]) {
-        [self attr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf lt_];
+    [PKParser_weakSelf scriptTagName_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf attr_];}]) {
+        [PKParser_weakSelf attr_];
     }
-    [self gt_]; 
+    [PKParser_weakSelf gt_];
 
 }
 
@@ -259,11 +261,11 @@
 }
 
 - (void)__scriptEndTag {
-    
-    [self lt_]; 
-    [self fwdSlash_]; 
-    [self scriptTagName_]; 
-    [self gt_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf lt_];
+    [PKParser_weakSelf fwdSlash_];
+    [PKParser_weakSelf scriptTagName_];
+    [PKParser_weakSelf gt_];
 
 }
 
@@ -272,8 +274,8 @@
 }
 
 - (void)__scriptTagName {
-    
-    [self match:HTML_TOKEN_KIND_SCRIPTTAGNAME discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:HTML_TOKEN_KIND_SCRIPTTAGNAME discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchScriptTagName:)];
 }
@@ -283,11 +285,11 @@
 }
 
 - (void)__scriptElementContent {
-    
-    if (![self speculate:^{ [self scriptEndTag_]; }]) {
-        [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
+    PKParser_weakSelfDecl;
+    if (![PKParser_weakSelf speculate:^{ [PKParser_weakSelf scriptEndTag_];}]) {
+        [PKParser_weakSelf match:TOKEN_KIND_BUILTIN_ANY discard:NO];
     } else {
-        [self raise:@"negation test failed in scriptElementContent"];
+        [PKParser_weakSelf raise:@"negation test failed in scriptElementContent"];
     }
 
 }
@@ -297,10 +299,10 @@
 }
 
 - (void)__styleElement {
-    
-    [self styleStartTag_]; 
-    [self styleElementContent_]; 
-    [self styleEndTag_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf styleStartTag_];
+    [PKParser_weakSelf styleElementContent_];
+    [PKParser_weakSelf styleEndTag_];
 
 }
 
@@ -309,13 +311,13 @@
 }
 
 - (void)__styleStartTag {
-    
-    [self lt_]; 
-    [self styleTagName_]; 
-    while ([self speculate:^{ [self attr_]; }]) {
-        [self attr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf lt_];
+    [PKParser_weakSelf styleTagName_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf attr_];}]) {
+        [PKParser_weakSelf attr_];
     }
-    [self gt_]; 
+    [PKParser_weakSelf gt_];
 
 }
 
@@ -324,11 +326,11 @@
 }
 
 - (void)__styleEndTag {
-    
-    [self lt_]; 
-    [self fwdSlash_]; 
-    [self styleTagName_]; 
-    [self gt_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf lt_];
+    [PKParser_weakSelf fwdSlash_];
+    [PKParser_weakSelf styleTagName_];
+    [PKParser_weakSelf gt_];
 
 }
 
@@ -337,8 +339,8 @@
 }
 
 - (void)__styleTagName {
-    
-    [self match:HTML_TOKEN_KIND_STYLETAGNAME discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:HTML_TOKEN_KIND_STYLETAGNAME discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchStyleTagName:)];
 }
@@ -348,11 +350,11 @@
 }
 
 - (void)__styleElementContent {
-    
-    if (![self speculate:^{ [self styleEndTag_]; }]) {
-        [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
+    PKParser_weakSelfDecl;
+    if (![PKParser_weakSelf speculate:^{ [PKParser_weakSelf styleEndTag_];}]) {
+        [PKParser_weakSelf match:TOKEN_KIND_BUILTIN_ANY discard:NO];
     } else {
-        [self raise:@"negation test failed in styleElementContent"];
+        [PKParser_weakSelf raise:@"negation test failed in styleElementContent"];
     }
 
 }
@@ -362,7 +364,7 @@
 }
 
 - (void)__procInstr {
-    
+    PKParser_weakSelfDecl;
     [self match:HTML_TOKEN_KIND_PROCINSTR discard:NO]; 
 
     [self fireDelegateSelector:@selector(parser:didMatchProcInstr:)];
@@ -373,7 +375,7 @@
 }
 
 - (void)__doctype {
-    
+    PKParser_weakSelfDecl;
     [self match:HTML_TOKEN_KIND_DOCTYPE discard:NO]; 
 
     [self fireDelegateSelector:@selector(parser:didMatchDoctype:)];
@@ -384,8 +386,8 @@
 }
 
 - (void)__text {
-    
-    [self matchAny:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchAny:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchText:)];
 }
@@ -395,15 +397,15 @@
 }
 
 - (void)__tag {
-    
-    if ([self speculate:^{ [self emptyTag_]; }]) {
-        [self emptyTag_]; 
-    } else if ([self speculate:^{ [self startTag_]; }]) {
-        [self startTag_]; 
-    } else if ([self speculate:^{ [self endTag_]; }]) {
-        [self endTag_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf emptyTag_];}]) {
+        [PKParser_weakSelf emptyTag_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf startTag_];}]) {
+        [PKParser_weakSelf startTag_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf endTag_];}]) {
+        [PKParser_weakSelf endTag_];
     } else {
-        [self raise:@"No viable alternative found in rule 'tag'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'tag'."];
     }
 
 }
@@ -413,14 +415,14 @@
 }
 
 - (void)__emptyTag {
-    
-    [self lt_]; 
-    [self tagName_]; 
-    while ([self speculate:^{ [self attr_]; }]) {
-        [self attr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf lt_];
+    [PKParser_weakSelf tagName_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf attr_];}]) {
+        [PKParser_weakSelf attr_];
     }
-    [self fwdSlash_]; 
-    [self gt_]; 
+    [PKParser_weakSelf fwdSlash_];
+    [PKParser_weakSelf gt_];
 
 }
 
@@ -429,13 +431,13 @@
 }
 
 - (void)__startTag {
-    
-    [self lt_]; 
-    [self tagName_]; 
-    while ([self speculate:^{ [self attr_]; }]) {
-        [self attr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf lt_];
+    [PKParser_weakSelf tagName_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf attr_];}]) {
+        [PKParser_weakSelf attr_];
     }
-    [self gt_]; 
+    [PKParser_weakSelf gt_];
 
 }
 
@@ -444,11 +446,11 @@
 }
 
 - (void)__endTag {
-    
-    [self lt_]; 
-    [self fwdSlash_]; 
-    [self tagName_]; 
-    [self gt_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf lt_];
+    [PKParser_weakSelf fwdSlash_];
+    [PKParser_weakSelf tagName_];
+    [PKParser_weakSelf gt_];
 
 }
 
@@ -457,8 +459,8 @@
 }
 
 - (void)__tagName {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTagName:)];
 }
@@ -468,12 +470,12 @@
 }
 
 - (void)__attr {
-    
-    [self attrName_]; 
-    if ([self speculate:^{ [self eq_]; if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {[self attrValue_]; }}]) {
-        [self eq_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf attrName_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf eq_];if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {[PKParser_weakSelf attrValue_];}}]) {
+        [PKParser_weakSelf eq_];
         if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
-            [self attrValue_]; 
+            [PKParser_weakSelf attrValue_];
         }
     }
 
@@ -484,8 +486,8 @@
 }
 
 - (void)__attrName {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchAttrName:)];
 }
@@ -495,13 +497,13 @@
 }
 
 - (void)__attrValue {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self matchWord:NO]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf matchWord:NO];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf matchQuotedString:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'attrValue'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'attrValue'."];
     }
 
 }
@@ -511,8 +513,8 @@
 }
 
 - (void)__eq {
-    
-    [self match:HTML_TOKEN_KIND_EQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:HTML_TOKEN_KIND_EQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchEq:)];
 }
@@ -522,8 +524,8 @@
 }
 
 - (void)__lt {
-    
-    [self match:HTML_TOKEN_KIND_LT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:HTML_TOKEN_KIND_LT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLt:)];
 }
@@ -533,8 +535,8 @@
 }
 
 - (void)__gt {
-    
-    [self match:HTML_TOKEN_KIND_GT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:HTML_TOKEN_KIND_GT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchGt:)];
 }
@@ -544,8 +546,8 @@
 }
 
 - (void)__fwdSlash {
-    
-    [self match:HTML_TOKEN_KIND_FWDSLASH discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:HTML_TOKEN_KIND_FWDSLASH discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchFwdSlash:)];
 }
@@ -555,8 +557,8 @@
 }
 
 - (void)__comment {
-    
-    [self matchComment:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchComment:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchComment:)];
 }

--- a/test/INIParser.m
+++ b/test/INIParser.m
@@ -1,5 +1,6 @@
 #import "INIParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface INIParser ()
@@ -52,7 +53,8 @@
 }
 
 - (void)start {
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
     self.sections = [NSMutableDictionary dictionary];
     self.currentSectionName = @"[[Default]]";
@@ -67,64 +69,64 @@
 
     }];
 
-    [self sections_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf sections_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)sections_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self section_]; 
-    } while ([self speculate:^{ [self section_]; }]);
+        [PKParser_weakSelf section_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf section_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchSections:)];
 }
 
 - (void)section_ {
-    
-    if ([self speculate:^{ [self header_]; }]) {
-        [self header_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf header_];}]) {
+        [PKParser_weakSelf header_];
     }
     do {
-        [self keyVal_]; 
-    } while ([self speculate:^{ [self keyVal_]; }]);
+        [PKParser_weakSelf keyVal_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf keyVal_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchSection:)];
 }
 
 - (void)header_ {
-    
-    [self match:INI_TOKEN_KIND_OPEN_BRACKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:INI_TOKEN_KIND_OPEN_BRACKET discard:NO];
     do {
         if (![self predicts:INI_TOKEN_KIND_CLOSE_BRACKET, 0]) {
             [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
         } else {
             [self raise:@"negation test failed in header"];
         }
-    } while ([self speculate:^{ if (![self predicts:INI_TOKEN_KIND_CLOSE_BRACKET, 0]) {[self match:TOKEN_KIND_BUILTIN_ANY discard:NO];} else {[self raise:@"negation test failed in header"];}}]);
-    [self match:INI_TOKEN_KIND_CLOSE_BRACKET discard:YES]; 
-    [self nl_]; 
+    } while ([PKParser_weakSelf speculate:^{ if (![self predicts:INI_TOKEN_KIND_CLOSE_BRACKET, 0]) {[self match:TOKEN_KIND_BUILTIN_ANY discard:NO];} else {[self raise:@"negation test failed in header"];}}]);
+    [PKParser_weakSelf match:INI_TOKEN_KIND_CLOSE_BRACKET discard:YES];
+    [PKParser_weakSelf nl_];
 
     [self fireDelegateSelector:@selector(parser:didMatchHeader:)];
 }
 
 - (void)keyVal_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self key_]; 
-    } while ([self speculate:^{ [self key_]; }]);
-    [self match:INI_TOKEN_KIND_EQUALS discard:YES]; 
+        [PKParser_weakSelf key_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf key_];}]);
+    [PKParser_weakSelf match:INI_TOKEN_KIND_EQUALS discard:YES];
     do {
-        [self val_]; 
-    } while ([self speculate:^{ [self val_]; }]);
-    [self nl_]; 
+        [PKParser_weakSelf val_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf val_];}]);
+    [PKParser_weakSelf nl_];
 
     [self fireDelegateSelector:@selector(parser:didMatchKeyVal:)];
 }
 
 - (void)key_ {
-    
+    PKParser_weakSelfDecl;
     if (![self predicts:INI_TOKEN_KIND_EQUALS, 0]) {
         [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
     } else {
@@ -135,25 +137,25 @@
 }
 
 - (void)val_ {
-    
-    if (![self speculate:^{ [self nl_]; }]) {
-        [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
+    PKParser_weakSelfDecl;
+    if (![PKParser_weakSelf speculate:^{ [PKParser_weakSelf nl_];}]) {
+        [PKParser_weakSelf match:TOKEN_KIND_BUILTIN_ANY discard:NO];
     } else {
-        [self raise:@"negation test failed in val"];
+        [PKParser_weakSelf raise:@"negation test failed in val"];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchVal:)];
 }
 
 - (void)nl_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        if ([self predicts:INI_TOKEN_KIND__N, 0]) {
-            [self match:INI_TOKEN_KIND__N discard:YES]; 
-        } else if ([self predicts:INI_TOKEN_KIND__R, 0]) {
-            [self match:INI_TOKEN_KIND__R discard:YES]; 
+        if ([PKParser_weakSelf predicts:INI_TOKEN_KIND__N, 0]) {
+            [PKParser_weakSelf match:INI_TOKEN_KIND__N discard:YES];
+        } else if ([PKParser_weakSelf predicts:INI_TOKEN_KIND__R, 0]) {
+            [PKParser_weakSelf match:INI_TOKEN_KIND__R discard:YES];
         } else {
-            [self raise:@"No viable alternative found in rule 'nl'."];
+            [PKParser_weakSelf raise:@"No viable alternative found in rule 'nl'."];
         }
     } while ([self predicts:INI_TOKEN_KIND__N, INI_TOKEN_KIND__R, 0]);
 

--- a/test/JSONParser.m
+++ b/test/JSONParser.m
@@ -1,5 +1,6 @@
 #import "JSONParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface JSONParser ()
@@ -44,15 +45,16 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)start_ {
-    
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
 	PKTokenizer *t = self.tokenizer;
 	
@@ -68,216 +70,216 @@
 	[t.commentState addMultiLineStartMarker:@"/*" endMarker:@"*/"];
 
     }];
-    if ([self predicts:JSON_TOKEN_KIND_OPENBRACKET, 0]) {
-        [self array_]; 
-    } else if ([self predicts:JSON_TOKEN_KIND_OPENCURLY, 0]) {
-        [self object_]; 
+    if ([PKParser_weakSelf predicts:JSON_TOKEN_KIND_OPENBRACKET, 0]) {
+        [PKParser_weakSelf array_];
+    } else if ([PKParser_weakSelf predicts:JSON_TOKEN_KIND_OPENCURLY, 0]) {
+        [PKParser_weakSelf object_];
     }
     if ([self predicts:TOKEN_KIND_BUILTIN_COMMENT, 0]) {
-        [self comment_]; 
+        [PKParser_weakSelf comment_];
     }
 
 }
 
 - (void)object_ {
-    
-    [self openCurly_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf openCurly_];
     if ([self predicts:TOKEN_KIND_BUILTIN_COMMENT, 0]) {
-        [self comment_]; 
+        [PKParser_weakSelf comment_];
     }
-    [self objectContent_]; 
-    [self closeCurly_]; 
+    [PKParser_weakSelf objectContent_];
+    [PKParser_weakSelf closeCurly_];
 
 }
 
 - (void)objectContent_ {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self actualObject_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf actualObject_];
     }
 
 }
 
 - (void)actualObject_ {
-    
-    [self property_]; 
-    while ([self speculate:^{ [self commaProperty_]; }]) {
-        [self commaProperty_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf property_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf commaProperty_];}]) {
+        [PKParser_weakSelf commaProperty_];
     }
 
 }
 
 - (void)property_ {
-    
-    [self propertyName_]; 
-    [self colon_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf propertyName_];
+    [PKParser_weakSelf colon_];
     if ([self predicts:TOKEN_KIND_BUILTIN_COMMENT, 0]) {
-        [self comment_]; 
+        [PKParser_weakSelf comment_];
     }
-    [self value_]; 
+    [PKParser_weakSelf value_];
 
 }
 
 - (void)commaProperty_ {
-    
-    [self comma_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf comma_];
     if ([self predicts:TOKEN_KIND_BUILTIN_COMMENT, 0]) {
-        [self comment_]; 
+        [PKParser_weakSelf comment_];
     }
-    [self property_]; 
+    [PKParser_weakSelf property_];
 
 }
 
 - (void)propertyName_ {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchPropertyName:)];
 }
 
 - (void)array_ {
-    
-    [self openBracket_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf openBracket_];
     if ([self predicts:TOKEN_KIND_BUILTIN_COMMENT, 0]) {
-        [self comment_]; 
+        [PKParser_weakSelf comment_];
     }
-    [self arrayContent_]; 
-    [self closeBracket_]; 
+    [PKParser_weakSelf arrayContent_];
+    [PKParser_weakSelf closeBracket_];
 
 }
 
 - (void)arrayContent_ {
-    
-    if ([self predicts:JSON_TOKEN_KIND_FALSE, JSON_TOKEN_KIND_NULLLITERAL, JSON_TOKEN_KIND_OPENBRACKET, JSON_TOKEN_KIND_OPENCURLY, JSON_TOKEN_KIND_TRUE, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self actualArray_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JSON_TOKEN_KIND_FALSE, JSON_TOKEN_KIND_NULLLITERAL, JSON_TOKEN_KIND_OPENBRACKET, JSON_TOKEN_KIND_OPENCURLY, JSON_TOKEN_KIND_TRUE, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf actualArray_];
     }
 
 }
 
 - (void)actualArray_ {
-    
-    [self value_]; 
-    while ([self speculate:^{ [self commaValue_]; }]) {
-        [self commaValue_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf value_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf commaValue_];}]) {
+        [PKParser_weakSelf commaValue_];
     }
 
 }
 
 - (void)commaValue_ {
-    
-    [self comma_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf comma_];
     if ([self predicts:TOKEN_KIND_BUILTIN_COMMENT, 0]) {
-        [self comment_]; 
+        [PKParser_weakSelf comment_];
     }
-    [self value_]; 
+    [PKParser_weakSelf value_];
 
 }
 
 - (void)value_ {
-    
-    if ([self predicts:JSON_TOKEN_KIND_NULLLITERAL, 0]) {
-        [self nullLiteral_]; 
-    } else if ([self predicts:JSON_TOKEN_KIND_TRUE, 0]) {
-        [self true_]; 
-    } else if ([self predicts:JSON_TOKEN_KIND_FALSE, 0]) {
-        [self false_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
-        [self number_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self string_]; 
-    } else if ([self predicts:JSON_TOKEN_KIND_OPENBRACKET, 0]) {
-        [self array_]; 
-    } else if ([self predicts:JSON_TOKEN_KIND_OPENCURLY, 0]) {
-        [self object_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JSON_TOKEN_KIND_NULLLITERAL, 0]) {
+        [PKParser_weakSelf nullLiteral_];
+    } else if ([PKParser_weakSelf predicts:JSON_TOKEN_KIND_TRUE, 0]) {
+        [PKParser_weakSelf true_];
+    } else if ([PKParser_weakSelf predicts:JSON_TOKEN_KIND_FALSE, 0]) {
+        [PKParser_weakSelf false_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
+        [PKParser_weakSelf number_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf string_];
+    } else if ([PKParser_weakSelf predicts:JSON_TOKEN_KIND_OPENBRACKET, 0]) {
+        [PKParser_weakSelf array_];
+    } else if ([PKParser_weakSelf predicts:JSON_TOKEN_KIND_OPENCURLY, 0]) {
+        [PKParser_weakSelf object_];
     } else {
-        [self raise:@"No viable alternative found in rule 'value'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'value'."];
     }
     if ([self predicts:TOKEN_KIND_BUILTIN_COMMENT, 0]) {
-        [self comment_]; 
+        [PKParser_weakSelf comment_];
     }
 
 }
 
 - (void)comment_ {
-    
-    [self matchComment:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchComment:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchComment:)];
 }
 
 - (void)string_ {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchString:)];
 }
 
 - (void)number_ {
-    
-    [self matchNumber:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNumber:)];
 }
 
 - (void)nullLiteral_ {
-    
-    [self match:JSON_TOKEN_KIND_NULLLITERAL discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JSON_TOKEN_KIND_NULLLITERAL discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNullLiteral:)];
 }
 
 - (void)true_ {
-    
-    [self match:JSON_TOKEN_KIND_TRUE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JSON_TOKEN_KIND_TRUE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTrue:)];
 }
 
 - (void)false_ {
-    
-    [self match:JSON_TOKEN_KIND_FALSE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JSON_TOKEN_KIND_FALSE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchFalse:)];
 }
 
 - (void)openCurly_ {
-    
-    [self match:JSON_TOKEN_KIND_OPENCURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JSON_TOKEN_KIND_OPENCURLY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOpenCurly:)];
 }
 
 - (void)closeCurly_ {
-    
-    [self match:JSON_TOKEN_KIND_CLOSECURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JSON_TOKEN_KIND_CLOSECURLY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchCloseCurly:)];
 }
 
 - (void)openBracket_ {
-    
-    [self match:JSON_TOKEN_KIND_OPENBRACKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JSON_TOKEN_KIND_OPENBRACKET discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOpenBracket:)];
 }
 
 - (void)closeBracket_ {
-    
-    [self match:JSON_TOKEN_KIND_CLOSEBRACKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JSON_TOKEN_KIND_CLOSEBRACKET discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchCloseBracket:)];
 }
 
 - (void)comma_ {
-    
-    [self match:JSON_TOKEN_KIND_COMMA discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JSON_TOKEN_KIND_COMMA discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchComma:)];
 }
 
 - (void)colon_ {
-    
-    [self match:JSON_TOKEN_KIND_COLON discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JSON_TOKEN_KIND_COLON discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchColon:)];
 }

--- a/test/JavaScriptParser.m
+++ b/test/JavaScriptParser.m
@@ -1,5 +1,6 @@
 #import "JavaScriptParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface JavaScriptParser ()
@@ -173,7 +174,8 @@
 }
 
 - (void)start {
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
         PKTokenizer *t = self.tokenizer;
 
@@ -211,8 +213,8 @@
     }];
 
     [self tryAndRecover:TOKEN_KIND_BUILTIN_EOF block:^{
-        [self program_]; 
-        [self matchEOF:YES]; 
+        [PKParser_weakSelf program_];
+        [PKParser_weakSelf matchEOF:YES];
     } completion:^{
         [self matchEOF:YES];
     }];
@@ -220,1354 +222,1354 @@
 }
 
 - (void)program_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self element_]; 
-    } while ([self speculate:^{ [self element_]; }]);
+        [PKParser_weakSelf element_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf element_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchProgram:)];
 }
 
 - (void)if_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_IF discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_IF discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchIf:)];
 }
 
 - (void)else_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_ELSE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_ELSE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchElse:)];
 }
 
 - (void)while_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_WHILE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_WHILE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchWhile:)];
 }
 
 - (void)for_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_FOR discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_FOR discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchFor:)];
 }
 
 - (void)in_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_IN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_IN discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchIn:)];
 }
 
 - (void)break_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_BREAK discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_BREAK discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchBreak:)];
 }
 
 - (void)continue_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_CONTINUE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_CONTINUE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchContinue:)];
 }
 
 - (void)with_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_WITH discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_WITH discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchWith:)];
 }
 
 - (void)return_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_RETURN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_RETURN discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchReturn:)];
 }
 
 - (void)var_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_VAR discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_VAR discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchVar:)];
 }
 
 - (void)delete_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_DELETE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_DELETE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDelete:)];
 }
 
 - (void)keywordNew_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_KEYWORDNEW discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_KEYWORDNEW discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchKeywordNew:)];
 }
 
 - (void)this_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_THIS discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_THIS discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchThis:)];
 }
 
 - (void)false_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_FALSE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_FALSE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchFalse:)];
 }
 
 - (void)true_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_TRUE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_TRUE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTrue:)];
 }
 
 - (void)null_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_NULL discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_NULL discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNull:)];
 }
 
 - (void)undefined_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_UNDEFINED discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_UNDEFINED discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchUndefined:)];
 }
 
 - (void)void_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_VOID discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_VOID discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchVoid:)];
 }
 
 - (void)typeof_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_TYPEOF discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_TYPEOF discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTypeof:)];
 }
 
 - (void)instanceof_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_INSTANCEOF discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_INSTANCEOF discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchInstanceof:)];
 }
 
 - (void)function_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_FUNCTION discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_FUNCTION discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchFunction:)];
 }
 
 - (void)openCurly_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_OPENCURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_OPENCURLY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOpenCurly:)];
 }
 
 - (void)closeCurly_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_CLOSECURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_CLOSECURLY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchCloseCurly:)];
 }
 
 - (void)openParen_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_OPENPAREN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_OPENPAREN discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOpenParen:)];
 }
 
 - (void)closeParen_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_CLOSEPAREN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_CLOSEPAREN discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchCloseParen:)];
 }
 
 - (void)openBracket_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_OPENBRACKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_OPENBRACKET discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOpenBracket:)];
 }
 
 - (void)closeBracket_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_CLOSEBRACKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_CLOSEBRACKET discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchCloseBracket:)];
 }
 
 - (void)comma_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_COMMA discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_COMMA discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchComma:)];
 }
 
 - (void)dot_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_DOT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_DOT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDot:)];
 }
 
 - (void)semi_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_SEMI discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_SEMI discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchSemi:)];
 }
 
 - (void)colon_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_COLON discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_COLON discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchColon:)];
 }
 
 - (void)equals_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_EQUALS discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_EQUALS discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchEquals:)];
 }
 
 - (void)not_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_NOT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_NOT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNot:)];
 }
 
 - (void)lt_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_LT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_LT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLt:)];
 }
 
 - (void)gt_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_GT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_GT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchGt:)];
 }
 
 - (void)amp_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_AMP discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_AMP discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchAmp:)];
 }
 
 - (void)pipe_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_PIPE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_PIPE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchPipe:)];
 }
 
 - (void)caret_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_CARET discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_CARET discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchCaret:)];
 }
 
 - (void)tilde_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_TILDE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_TILDE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTilde:)];
 }
 
 - (void)question_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_QUESTION discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_QUESTION discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchQuestion:)];
 }
 
 - (void)plus_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_PLUS discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_PLUS discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchPlus:)];
 }
 
 - (void)minus_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_MINUS discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_MINUS discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchMinus:)];
 }
 
 - (void)times_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_TIMES discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_TIMES discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTimes:)];
 }
 
 - (void)div_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_DIV discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_DIV discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDiv:)];
 }
 
 - (void)mod_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_MOD discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_MOD discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchMod:)];
 }
 
 - (void)or_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_OR discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_OR discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOr:)];
 }
 
 - (void)and_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_AND discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_AND discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchAnd:)];
 }
 
 - (void)ne_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_NE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_NE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNe:)];
 }
 
 - (void)isnot_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_ISNOT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_ISNOT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchIsnot:)];
 }
 
 - (void)eq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_EQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_EQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchEq:)];
 }
 
 - (void)is_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_IS discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_IS discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchIs:)];
 }
 
 - (void)le_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_LE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_LE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLe:)];
 }
 
 - (void)ge_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_GE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_GE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchGe:)];
 }
 
 - (void)plusPlus_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_PLUSPLUS discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_PLUSPLUS discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchPlusPlus:)];
 }
 
 - (void)minusMinus_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_MINUSMINUS discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_MINUSMINUS discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchMinusMinus:)];
 }
 
 - (void)plusEq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_PLUSEQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_PLUSEQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchPlusEq:)];
 }
 
 - (void)minusEq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_MINUSEQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_MINUSEQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchMinusEq:)];
 }
 
 - (void)timesEq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_TIMESEQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_TIMESEQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTimesEq:)];
 }
 
 - (void)divEq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_DIVEQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_DIVEQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDivEq:)];
 }
 
 - (void)modEq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_MODEQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_MODEQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchModEq:)];
 }
 
 - (void)shiftLeft_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_SHIFTLEFT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_SHIFTLEFT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchShiftLeft:)];
 }
 
 - (void)shiftRight_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchShiftRight:)];
 }
 
 - (void)shiftRightExt_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEXT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEXT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchShiftRightExt:)];
 }
 
 - (void)shiftLeftEq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_SHIFTLEFTEQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_SHIFTLEFTEQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchShiftLeftEq:)];
 }
 
 - (void)shiftRightEq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchShiftRightEq:)];
 }
 
 - (void)shiftRightExtEq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEXTEQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEXTEQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchShiftRightExtEq:)];
 }
 
 - (void)andEq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_ANDEQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_ANDEQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchAndEq:)];
 }
 
 - (void)xorEq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_XOREQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_XOREQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchXorEq:)];
 }
 
 - (void)orEq_ {
-    
-    [self match:JAVASCRIPT_TOKEN_KIND_OREQ discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:JAVASCRIPT_TOKEN_KIND_OREQ discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchOrEq:)];
 }
 
 - (void)assignmentOperator_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_EQUALS, 0]) {
-        [self equals_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_PLUSEQ, 0]) {
-        [self plusEq_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_MINUSEQ, 0]) {
-        [self minusEq_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_TIMESEQ, 0]) {
-        [self timesEq_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_DIVEQ, 0]) {
-        [self divEq_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_MODEQ, 0]) {
-        [self modEq_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_SHIFTLEFTEQ, 0]) {
-        [self shiftLeftEq_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEQ, 0]) {
-        [self shiftRightEq_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEXTEQ, 0]) {
-        [self shiftRightExtEq_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_ANDEQ, 0]) {
-        [self andEq_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_XOREQ, 0]) {
-        [self xorEq_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_OREQ, 0]) {
-        [self orEq_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_EQUALS, 0]) {
+        [PKParser_weakSelf equals_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_PLUSEQ, 0]) {
+        [PKParser_weakSelf plusEq_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_MINUSEQ, 0]) {
+        [PKParser_weakSelf minusEq_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_TIMESEQ, 0]) {
+        [PKParser_weakSelf timesEq_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_DIVEQ, 0]) {
+        [PKParser_weakSelf divEq_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_MODEQ, 0]) {
+        [PKParser_weakSelf modEq_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_SHIFTLEFTEQ, 0]) {
+        [PKParser_weakSelf shiftLeftEq_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEQ, 0]) {
+        [PKParser_weakSelf shiftRightEq_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEXTEQ, 0]) {
+        [PKParser_weakSelf shiftRightExtEq_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_ANDEQ, 0]) {
+        [PKParser_weakSelf andEq_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_XOREQ, 0]) {
+        [PKParser_weakSelf xorEq_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_OREQ, 0]) {
+        [PKParser_weakSelf orEq_];
     } else {
-        [self raise:@"No viable alternative found in rule 'assignmentOperator'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'assignmentOperator'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAssignmentOperator:)];
 }
 
 - (void)relationalOperator_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_LT, 0]) {
-        [self lt_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_GT, 0]) {
-        [self gt_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_GE, 0]) {
-        [self ge_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_LE, 0]) {
-        [self le_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_INSTANCEOF, 0]) {
-        [self instanceof_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_LT, 0]) {
+        [PKParser_weakSelf lt_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_GT, 0]) {
+        [PKParser_weakSelf gt_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_GE, 0]) {
+        [PKParser_weakSelf ge_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_LE, 0]) {
+        [PKParser_weakSelf le_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_INSTANCEOF, 0]) {
+        [PKParser_weakSelf instanceof_];
     } else {
-        [self raise:@"No viable alternative found in rule 'relationalOperator'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'relationalOperator'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchRelationalOperator:)];
 }
 
 - (void)equalityOperator_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_EQ, 0]) {
-        [self eq_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_NE, 0]) {
-        [self ne_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_IS, 0]) {
-        [self is_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_ISNOT, 0]) {
-        [self isnot_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_EQ, 0]) {
+        [PKParser_weakSelf eq_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_NE, 0]) {
+        [PKParser_weakSelf ne_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_IS, 0]) {
+        [PKParser_weakSelf is_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_ISNOT, 0]) {
+        [PKParser_weakSelf isnot_];
     } else {
-        [self raise:@"No viable alternative found in rule 'equalityOperator'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'equalityOperator'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchEqualityOperator:)];
 }
 
 - (void)shiftOperator_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_SHIFTLEFT, 0]) {
-        [self shiftLeft_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHT, 0]) {
-        [self shiftRight_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEXT, 0]) {
-        [self shiftRightExt_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_SHIFTLEFT, 0]) {
+        [PKParser_weakSelf shiftLeft_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHT, 0]) {
+        [PKParser_weakSelf shiftRight_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_SHIFTRIGHTEXT, 0]) {
+        [PKParser_weakSelf shiftRightExt_];
     } else {
-        [self raise:@"No viable alternative found in rule 'shiftOperator'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'shiftOperator'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchShiftOperator:)];
 }
 
 - (void)incrementOperator_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_PLUSPLUS, 0]) {
-        [self plusPlus_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_MINUSMINUS, 0]) {
-        [self minusMinus_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_PLUSPLUS, 0]) {
+        [PKParser_weakSelf plusPlus_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_MINUSMINUS, 0]) {
+        [PKParser_weakSelf minusMinus_];
     } else {
-        [self raise:@"No viable alternative found in rule 'incrementOperator'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'incrementOperator'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchIncrementOperator:)];
 }
 
 - (void)unaryOperator_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_TILDE, 0]) {
-        [self tilde_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_DELETE, 0]) {
-        [self delete_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_TYPEOF, 0]) {
-        [self typeof_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_VOID, 0]) {
-        [self void_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_TILDE, 0]) {
+        [PKParser_weakSelf tilde_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_DELETE, 0]) {
+        [PKParser_weakSelf delete_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_TYPEOF, 0]) {
+        [PKParser_weakSelf typeof_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_VOID, 0]) {
+        [PKParser_weakSelf void_];
     } else {
-        [self raise:@"No viable alternative found in rule 'unaryOperator'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'unaryOperator'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchUnaryOperator:)];
 }
 
 - (void)multiplicativeOperator_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_TIMES, 0]) {
-        [self times_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_DIV, 0]) {
-        [self div_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_MOD, 0]) {
-        [self mod_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_TIMES, 0]) {
+        [PKParser_weakSelf times_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_DIV, 0]) {
+        [PKParser_weakSelf div_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_MOD, 0]) {
+        [PKParser_weakSelf mod_];
     } else {
-        [self raise:@"No viable alternative found in rule 'multiplicativeOperator'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'multiplicativeOperator'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchMultiplicativeOperator:)];
 }
 
 - (void)element_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_FUNCTION, 0]) {
-        [self func_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_BREAK, JAVASCRIPT_TOKEN_KIND_CONTINUE, JAVASCRIPT_TOKEN_KIND_DELETE, JAVASCRIPT_TOKEN_KIND_FALSE, JAVASCRIPT_TOKEN_KIND_FOR, JAVASCRIPT_TOKEN_KIND_IF, JAVASCRIPT_TOKEN_KIND_KEYWORDNEW, JAVASCRIPT_TOKEN_KIND_MINUS, JAVASCRIPT_TOKEN_KIND_MINUSMINUS, JAVASCRIPT_TOKEN_KIND_NULL, JAVASCRIPT_TOKEN_KIND_OPENCURLY, JAVASCRIPT_TOKEN_KIND_OPENPAREN, JAVASCRIPT_TOKEN_KIND_PLUSPLUS, JAVASCRIPT_TOKEN_KIND_RETURN, JAVASCRIPT_TOKEN_KIND_SEMI, JAVASCRIPT_TOKEN_KIND_THIS, JAVASCRIPT_TOKEN_KIND_TILDE, JAVASCRIPT_TOKEN_KIND_TRUE, JAVASCRIPT_TOKEN_KIND_TYPEOF, JAVASCRIPT_TOKEN_KIND_UNDEFINED, JAVASCRIPT_TOKEN_KIND_VAR, JAVASCRIPT_TOKEN_KIND_VOID, JAVASCRIPT_TOKEN_KIND_WHILE, JAVASCRIPT_TOKEN_KIND_WITH, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self stmt_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_FUNCTION, 0]) {
+        [PKParser_weakSelf func_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_BREAK, JAVASCRIPT_TOKEN_KIND_CONTINUE, JAVASCRIPT_TOKEN_KIND_DELETE, JAVASCRIPT_TOKEN_KIND_FALSE, JAVASCRIPT_TOKEN_KIND_FOR, JAVASCRIPT_TOKEN_KIND_IF, JAVASCRIPT_TOKEN_KIND_KEYWORDNEW, JAVASCRIPT_TOKEN_KIND_MINUS, JAVASCRIPT_TOKEN_KIND_MINUSMINUS, JAVASCRIPT_TOKEN_KIND_NULL, JAVASCRIPT_TOKEN_KIND_OPENCURLY, JAVASCRIPT_TOKEN_KIND_OPENPAREN, JAVASCRIPT_TOKEN_KIND_PLUSPLUS, JAVASCRIPT_TOKEN_KIND_RETURN, JAVASCRIPT_TOKEN_KIND_SEMI, JAVASCRIPT_TOKEN_KIND_THIS, JAVASCRIPT_TOKEN_KIND_TILDE, JAVASCRIPT_TOKEN_KIND_TRUE, JAVASCRIPT_TOKEN_KIND_TYPEOF, JAVASCRIPT_TOKEN_KIND_UNDEFINED, JAVASCRIPT_TOKEN_KIND_VAR, JAVASCRIPT_TOKEN_KIND_VOID, JAVASCRIPT_TOKEN_KIND_WHILE, JAVASCRIPT_TOKEN_KIND_WITH, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf stmt_];
     } else {
-        [self raise:@"No viable alternative found in rule 'element'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'element'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchElement:)];
 }
 
 - (void)func_ {
-    
-    [self function_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf function_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_OPENPAREN block:^{ 
-        [self identifier_]; 
-        [self openParen_]; 
+        [PKParser_weakSelf identifier_];
+        [PKParser_weakSelf openParen_];
     } completion:^{ 
-        [self openParen_]; 
+        [PKParser_weakSelf openParen_];
     }];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_CLOSEPAREN block:^{ 
-        [self paramListOpt_]; 
-        [self closeParen_]; 
+        [PKParser_weakSelf paramListOpt_];
+        [PKParser_weakSelf closeParen_];
     } completion:^{ 
-        [self closeParen_]; 
+        [PKParser_weakSelf closeParen_];
     }];
-        [self compoundStmt_]; 
+        [PKParser_weakSelf compoundStmt_];
 
     [self fireDelegateSelector:@selector(parser:didMatchFunc:)];
 }
 
 - (void)paramListOpt_ {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self paramList_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf paramList_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchParamListOpt:)];
 }
 
 - (void)paramList_ {
-    
-    [self identifier_]; 
-    while ([self speculate:^{ [self commaIdentifier_]; }]) {
-        [self commaIdentifier_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf identifier_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf commaIdentifier_];}]) {
+        [PKParser_weakSelf commaIdentifier_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchParamList:)];
 }
 
 - (void)commaIdentifier_ {
-    
-    [self comma_]; 
-    [self identifier_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf comma_];
+    [PKParser_weakSelf identifier_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCommaIdentifier:)];
 }
 
 - (void)compoundStmt_ {
-    
-    [self openCurly_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf openCurly_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_CLOSECURLY block:^{ 
-        [self stmts_]; 
-        [self closeCurly_]; 
+        [PKParser_weakSelf stmts_];
+        [PKParser_weakSelf closeCurly_];
     } completion:^{ 
-        [self closeCurly_]; 
+        [PKParser_weakSelf closeCurly_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchCompoundStmt:)];
 }
 
 - (void)stmts_ {
-    
-    while ([self speculate:^{ [self stmt_]; }]) {
-        [self stmt_]; 
+    PKParser_weakSelfDecl;
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf stmt_];}]) {
+        [PKParser_weakSelf stmt_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchStmts:)];
 }
 
 - (void)stmt_ {
-    
-    if ([self speculate:^{ [self semi_]; }]) {
-        [self semi_]; 
-    } else if ([self speculate:^{ [self ifStmt_]; }]) {
-        [self ifStmt_]; 
-    } else if ([self speculate:^{ [self ifElseStmt_]; }]) {
-        [self ifElseStmt_]; 
-    } else if ([self speculate:^{ [self whileStmt_]; }]) {
-        [self whileStmt_]; 
-    } else if ([self speculate:^{ [self forParenStmt_]; }]) {
-        [self forParenStmt_]; 
-    } else if ([self speculate:^{ [self forBeginStmt_]; }]) {
-        [self forBeginStmt_]; 
-    } else if ([self speculate:^{ [self forInStmt_]; }]) {
-        [self forInStmt_]; 
-    } else if ([self speculate:^{ [self breakStmt_]; }]) {
-        [self breakStmt_]; 
-    } else if ([self speculate:^{ [self continueStmt_]; }]) {
-        [self continueStmt_]; 
-    } else if ([self speculate:^{ [self withStmt_]; }]) {
-        [self withStmt_]; 
-    } else if ([self speculate:^{ [self returnStmt_]; }]) {
-        [self returnStmt_]; 
-    } else if ([self speculate:^{ [self compoundStmt_]; }]) {
-        [self compoundStmt_]; 
-    } else if ([self speculate:^{ [self variablesOrExprStmt_]; }]) {
-        [self variablesOrExprStmt_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf semi_];}]) {
+        [PKParser_weakSelf semi_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf ifStmt_];}]) {
+        [PKParser_weakSelf ifStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf ifElseStmt_];}]) {
+        [PKParser_weakSelf ifElseStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf whileStmt_];}]) {
+        [PKParser_weakSelf whileStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf forParenStmt_];}]) {
+        [PKParser_weakSelf forParenStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf forBeginStmt_];}]) {
+        [PKParser_weakSelf forBeginStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf forInStmt_];}]) {
+        [PKParser_weakSelf forInStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf breakStmt_];}]) {
+        [PKParser_weakSelf breakStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf continueStmt_];}]) {
+        [PKParser_weakSelf continueStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf withStmt_];}]) {
+        [PKParser_weakSelf withStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf returnStmt_];}]) {
+        [PKParser_weakSelf returnStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf compoundStmt_];}]) {
+        [PKParser_weakSelf compoundStmt_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf variablesOrExprStmt_];}]) {
+        [PKParser_weakSelf variablesOrExprStmt_];
     } else {
-        [self raise:@"No viable alternative found in rule 'stmt'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'stmt'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchStmt:)];
 }
 
 - (void)ifStmt_ {
-    
-    [self if_]; 
-    [self condition_]; 
-    [self stmt_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf if_];
+    [PKParser_weakSelf condition_];
+    [PKParser_weakSelf stmt_];
 
     [self fireDelegateSelector:@selector(parser:didMatchIfStmt:)];
 }
 
 - (void)ifElseStmt_ {
-    
-    [self if_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf if_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_ELSE block:^{ 
-        [self condition_]; 
-        [self stmt_]; 
-        [self else_]; 
+        [PKParser_weakSelf condition_];
+        [PKParser_weakSelf stmt_];
+        [PKParser_weakSelf else_];
     } completion:^{ 
-        [self else_]; 
+        [PKParser_weakSelf else_];
     }];
-        [self stmt_]; 
+        [PKParser_weakSelf stmt_];
 
     [self fireDelegateSelector:@selector(parser:didMatchIfElseStmt:)];
 }
 
 - (void)whileStmt_ {
-    
-    [self while_]; 
-    [self condition_]; 
-    [self stmt_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf while_];
+    [PKParser_weakSelf condition_];
+    [PKParser_weakSelf stmt_];
 
     [self fireDelegateSelector:@selector(parser:didMatchWhileStmt:)];
 }
 
 - (void)forParenStmt_ {
-    
+    PKParser_weakSelfDecl;
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_SEMI block:^{ 
-        [self forParen_]; 
-        [self semi_]; 
+        [PKParser_weakSelf forParen_];
+        [PKParser_weakSelf semi_];
     } completion:^{ 
-        [self semi_]; 
+        [PKParser_weakSelf semi_];
     }];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_SEMI block:^{ 
-        [self exprOpt_]; 
-        [self semi_]; 
+        [PKParser_weakSelf exprOpt_];
+        [PKParser_weakSelf semi_];
     } completion:^{ 
-        [self semi_]; 
+        [PKParser_weakSelf semi_];
     }];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_CLOSEPAREN block:^{ 
-        [self exprOpt_]; 
-        [self closeParen_]; 
+        [PKParser_weakSelf exprOpt_];
+        [PKParser_weakSelf closeParen_];
     } completion:^{ 
-        [self closeParen_]; 
+        [PKParser_weakSelf closeParen_];
     }];
-        [self stmt_]; 
+        [PKParser_weakSelf stmt_];
 
     [self fireDelegateSelector:@selector(parser:didMatchForParenStmt:)];
 }
 
 - (void)forBeginStmt_ {
-    
+    PKParser_weakSelfDecl;
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_SEMI block:^{ 
-        [self forBegin_]; 
-        [self semi_]; 
+        [PKParser_weakSelf forBegin_];
+        [PKParser_weakSelf semi_];
     } completion:^{ 
-        [self semi_]; 
+        [PKParser_weakSelf semi_];
     }];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_SEMI block:^{ 
-        [self exprOpt_]; 
-        [self semi_]; 
+        [PKParser_weakSelf exprOpt_];
+        [PKParser_weakSelf semi_];
     } completion:^{ 
-        [self semi_]; 
+        [PKParser_weakSelf semi_];
     }];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_CLOSEPAREN block:^{ 
-        [self exprOpt_]; 
-        [self closeParen_]; 
+        [PKParser_weakSelf exprOpt_];
+        [PKParser_weakSelf closeParen_];
     } completion:^{ 
-        [self closeParen_]; 
+        [PKParser_weakSelf closeParen_];
     }];
-        [self stmt_]; 
+        [PKParser_weakSelf stmt_];
 
     [self fireDelegateSelector:@selector(parser:didMatchForBeginStmt:)];
 }
 
 - (void)forInStmt_ {
-    
+    PKParser_weakSelfDecl;
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_IN block:^{ 
-        [self forBegin_]; 
-        [self in_]; 
+        [PKParser_weakSelf forBegin_];
+        [PKParser_weakSelf in_];
     } completion:^{ 
-        [self in_]; 
+        [PKParser_weakSelf in_];
     }];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_CLOSEPAREN block:^{ 
-        [self expr_]; 
-        [self closeParen_]; 
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf closeParen_];
     } completion:^{ 
-        [self closeParen_]; 
+        [PKParser_weakSelf closeParen_];
     }];
-        [self stmt_]; 
+        [PKParser_weakSelf stmt_];
 
     [self fireDelegateSelector:@selector(parser:didMatchForInStmt:)];
 }
 
 - (void)breakStmt_ {
-    
-    [self break_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf break_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_SEMI block:^{ 
-        [self semi_]; 
+        [PKParser_weakSelf semi_];
     } completion:^{ 
-        [self semi_]; 
+        [PKParser_weakSelf semi_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchBreakStmt:)];
 }
 
 - (void)continueStmt_ {
-    
-    [self continue_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf continue_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_SEMI block:^{ 
-        [self semi_]; 
+        [PKParser_weakSelf semi_];
     } completion:^{ 
-        [self semi_]; 
+        [PKParser_weakSelf semi_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchContinueStmt:)];
 }
 
 - (void)withStmt_ {
-    
-    [self with_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf with_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_OPENPAREN block:^{ 
-        [self openParen_]; 
+        [PKParser_weakSelf openParen_];
     } completion:^{ 
-        [self openParen_]; 
+        [PKParser_weakSelf openParen_];
     }];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_CLOSEPAREN block:^{ 
-        [self expr_]; 
-        [self closeParen_]; 
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf closeParen_];
     } completion:^{ 
-        [self closeParen_]; 
+        [PKParser_weakSelf closeParen_];
     }];
-        [self stmt_]; 
+        [PKParser_weakSelf stmt_];
 
     [self fireDelegateSelector:@selector(parser:didMatchWithStmt:)];
 }
 
 - (void)returnStmt_ {
-    
-    [self return_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf return_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_SEMI block:^{ 
-        [self exprOpt_]; 
-        [self semi_]; 
+        [PKParser_weakSelf exprOpt_];
+        [PKParser_weakSelf semi_];
     } completion:^{ 
-        [self semi_]; 
+        [PKParser_weakSelf semi_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchReturnStmt:)];
 }
 
 - (void)variablesOrExprStmt_ {
-    
+    PKParser_weakSelfDecl;
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_SEMI block:^{ 
-        [self variablesOrExpr_]; 
-        [self semi_]; 
+        [PKParser_weakSelf variablesOrExpr_];
+        [PKParser_weakSelf semi_];
     } completion:^{ 
-        [self semi_]; 
+        [PKParser_weakSelf semi_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchVariablesOrExprStmt:)];
 }
 
 - (void)condition_ {
-    
-    [self openParen_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf openParen_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_CLOSEPAREN block:^{ 
-        [self expr_]; 
-        [self closeParen_]; 
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf closeParen_];
     } completion:^{ 
-        [self closeParen_]; 
+        [PKParser_weakSelf closeParen_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchCondition:)];
 }
 
 - (void)forParen_ {
-    
-    [self for_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf for_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_OPENPAREN block:^{ 
-        [self openParen_]; 
+        [PKParser_weakSelf openParen_];
     } completion:^{ 
-        [self openParen_]; 
+        [PKParser_weakSelf openParen_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchForParen:)];
 }
 
 - (void)forBegin_ {
-    
-    [self forParen_]; 
-    [self variablesOrExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf forParen_];
+    [PKParser_weakSelf variablesOrExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchForBegin:)];
 }
 
 - (void)variablesOrExpr_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_VAR, 0]) {
-        [self varVariables_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_DELETE, JAVASCRIPT_TOKEN_KIND_FALSE, JAVASCRIPT_TOKEN_KIND_KEYWORDNEW, JAVASCRIPT_TOKEN_KIND_MINUS, JAVASCRIPT_TOKEN_KIND_MINUSMINUS, JAVASCRIPT_TOKEN_KIND_NULL, JAVASCRIPT_TOKEN_KIND_OPENPAREN, JAVASCRIPT_TOKEN_KIND_PLUSPLUS, JAVASCRIPT_TOKEN_KIND_THIS, JAVASCRIPT_TOKEN_KIND_TILDE, JAVASCRIPT_TOKEN_KIND_TRUE, JAVASCRIPT_TOKEN_KIND_TYPEOF, JAVASCRIPT_TOKEN_KIND_UNDEFINED, JAVASCRIPT_TOKEN_KIND_VOID, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self expr_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_VAR, 0]) {
+        [PKParser_weakSelf varVariables_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_DELETE, JAVASCRIPT_TOKEN_KIND_FALSE, JAVASCRIPT_TOKEN_KIND_KEYWORDNEW, JAVASCRIPT_TOKEN_KIND_MINUS, JAVASCRIPT_TOKEN_KIND_MINUSMINUS, JAVASCRIPT_TOKEN_KIND_NULL, JAVASCRIPT_TOKEN_KIND_OPENPAREN, JAVASCRIPT_TOKEN_KIND_PLUSPLUS, JAVASCRIPT_TOKEN_KIND_THIS, JAVASCRIPT_TOKEN_KIND_TILDE, JAVASCRIPT_TOKEN_KIND_TRUE, JAVASCRIPT_TOKEN_KIND_TYPEOF, JAVASCRIPT_TOKEN_KIND_UNDEFINED, JAVASCRIPT_TOKEN_KIND_VOID, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf expr_];
     } else {
-        [self raise:@"No viable alternative found in rule 'variablesOrExpr'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'variablesOrExpr'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchVariablesOrExpr:)];
 }
 
 - (void)varVariables_ {
-    
-    [self var_]; 
-    [self variables_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf var_];
+    [PKParser_weakSelf variables_];
 
     [self fireDelegateSelector:@selector(parser:didMatchVarVariables:)];
 }
 
 - (void)variables_ {
-    
-    [self variable_]; 
-    while ([self speculate:^{ [self commaVariable_]; }]) {
-        [self commaVariable_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf variable_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf commaVariable_];}]) {
+        [PKParser_weakSelf commaVariable_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchVariables:)];
 }
 
 - (void)commaVariable_ {
-    
-    [self comma_]; 
-    [self variable_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf comma_];
+    [PKParser_weakSelf variable_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCommaVariable:)];
 }
 
 - (void)variable_ {
-    
-    [self identifier_]; 
-    if ([self speculate:^{ [self assignment_]; }]) {
-        [self assignment_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf identifier_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf assignment_];}]) {
+        [PKParser_weakSelf assignment_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchVariable:)];
 }
 
 - (void)assignment_ {
-    
-    [self equals_]; 
-    [self assignmentExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf equals_];
+    [PKParser_weakSelf assignmentExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchAssignment:)];
 }
 
 - (void)exprOpt_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_DELETE, JAVASCRIPT_TOKEN_KIND_FALSE, JAVASCRIPT_TOKEN_KIND_KEYWORDNEW, JAVASCRIPT_TOKEN_KIND_MINUS, JAVASCRIPT_TOKEN_KIND_MINUSMINUS, JAVASCRIPT_TOKEN_KIND_NULL, JAVASCRIPT_TOKEN_KIND_OPENPAREN, JAVASCRIPT_TOKEN_KIND_PLUSPLUS, JAVASCRIPT_TOKEN_KIND_THIS, JAVASCRIPT_TOKEN_KIND_TILDE, JAVASCRIPT_TOKEN_KIND_TRUE, JAVASCRIPT_TOKEN_KIND_TYPEOF, JAVASCRIPT_TOKEN_KIND_UNDEFINED, JAVASCRIPT_TOKEN_KIND_VOID, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self expr_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_DELETE, JAVASCRIPT_TOKEN_KIND_FALSE, JAVASCRIPT_TOKEN_KIND_KEYWORDNEW, JAVASCRIPT_TOKEN_KIND_MINUS, JAVASCRIPT_TOKEN_KIND_MINUSMINUS, JAVASCRIPT_TOKEN_KIND_NULL, JAVASCRIPT_TOKEN_KIND_OPENPAREN, JAVASCRIPT_TOKEN_KIND_PLUSPLUS, JAVASCRIPT_TOKEN_KIND_THIS, JAVASCRIPT_TOKEN_KIND_TILDE, JAVASCRIPT_TOKEN_KIND_TRUE, JAVASCRIPT_TOKEN_KIND_TYPEOF, JAVASCRIPT_TOKEN_KIND_UNDEFINED, JAVASCRIPT_TOKEN_KIND_VOID, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf expr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchExprOpt:)];
 }
 
 - (void)expr_ {
-    
-    [self assignmentExpr_]; 
-    if ([self speculate:^{ [self commaExpr_]; }]) {
-        [self commaExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf assignmentExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf commaExpr_];}]) {
+        [PKParser_weakSelf commaExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchExpr:)];
 }
 
 - (void)commaExpr_ {
-    
-    [self comma_]; 
-    [self expr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf comma_];
+    [PKParser_weakSelf expr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCommaExpr:)];
 }
 
 - (void)assignmentExpr_ {
-    
-    [self conditionalExpr_]; 
-    if ([self speculate:^{ [self extraAssignment_]; }]) {
-        [self extraAssignment_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf conditionalExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf extraAssignment_];}]) {
+        [PKParser_weakSelf extraAssignment_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAssignmentExpr:)];
 }
 
 - (void)extraAssignment_ {
-    
-    [self assignmentOperator_]; 
-    [self assignmentExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf assignmentOperator_];
+    [PKParser_weakSelf assignmentExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchExtraAssignment:)];
 }
 
 - (void)conditionalExpr_ {
-    
-    [self orExpr_]; 
-    if ([self speculate:^{ [self ternaryExpr_]; }]) {
-        [self ternaryExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf orExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf ternaryExpr_];}]) {
+        [PKParser_weakSelf ternaryExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchConditionalExpr:)];
 }
 
 - (void)ternaryExpr_ {
-    
-    [self question_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf question_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_COLON block:^{ 
-        [self assignmentExpr_]; 
-        [self colon_]; 
+        [PKParser_weakSelf assignmentExpr_];
+        [PKParser_weakSelf colon_];
     } completion:^{ 
-        [self colon_]; 
+        [PKParser_weakSelf colon_];
     }];
-        [self assignmentExpr_]; 
+        [PKParser_weakSelf assignmentExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchTernaryExpr:)];
 }
 
 - (void)orExpr_ {
-    
-    [self andExpr_]; 
-    while ([self speculate:^{ [self orAndExpr_]; }]) {
-        [self orAndExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf andExpr_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf orAndExpr_];}]) {
+        [PKParser_weakSelf orAndExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchOrExpr:)];
 }
 
 - (void)orAndExpr_ {
-    
-    [self or_]; 
-    [self andExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf or_];
+    [PKParser_weakSelf andExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchOrAndExpr:)];
 }
 
 - (void)andExpr_ {
-    
-    [self bitwiseOrExpr_]; 
-    if ([self speculate:^{ [self andAndExpr_]; }]) {
-        [self andAndExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf bitwiseOrExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf andAndExpr_];}]) {
+        [PKParser_weakSelf andAndExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAndExpr:)];
 }
 
 - (void)andAndExpr_ {
-    
-    [self and_]; 
-    [self andExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf and_];
+    [PKParser_weakSelf andExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchAndAndExpr:)];
 }
 
 - (void)bitwiseOrExpr_ {
-    
-    [self bitwiseXorExpr_]; 
-    if ([self speculate:^{ [self pipeBitwiseOrExpr_]; }]) {
-        [self pipeBitwiseOrExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf bitwiseXorExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf pipeBitwiseOrExpr_];}]) {
+        [PKParser_weakSelf pipeBitwiseOrExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchBitwiseOrExpr:)];
 }
 
 - (void)pipeBitwiseOrExpr_ {
-    
-    [self pipe_]; 
-    [self bitwiseOrExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf pipe_];
+    [PKParser_weakSelf bitwiseOrExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchPipeBitwiseOrExpr:)];
 }
 
 - (void)bitwiseXorExpr_ {
-    
-    [self bitwiseAndExpr_]; 
-    if ([self speculate:^{ [self caretBitwiseXorExpr_]; }]) {
-        [self caretBitwiseXorExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf bitwiseAndExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf caretBitwiseXorExpr_];}]) {
+        [PKParser_weakSelf caretBitwiseXorExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchBitwiseXorExpr:)];
 }
 
 - (void)caretBitwiseXorExpr_ {
-    
-    [self caret_]; 
-    [self bitwiseXorExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf caret_];
+    [PKParser_weakSelf bitwiseXorExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCaretBitwiseXorExpr:)];
 }
 
 - (void)bitwiseAndExpr_ {
-    
-    [self equalityExpr_]; 
-    if ([self speculate:^{ [self ampBitwiseAndExpression_]; }]) {
-        [self ampBitwiseAndExpression_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf equalityExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf ampBitwiseAndExpression_];}]) {
+        [PKParser_weakSelf ampBitwiseAndExpression_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchBitwiseAndExpr:)];
 }
 
 - (void)ampBitwiseAndExpression_ {
-    
-    [self amp_]; 
-    [self bitwiseAndExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf amp_];
+    [PKParser_weakSelf bitwiseAndExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchAmpBitwiseAndExpression:)];
 }
 
 - (void)equalityExpr_ {
-    
-    [self relationalExpr_]; 
-    if ([self speculate:^{ [self equalityOpEqualityExpr_]; }]) {
-        [self equalityOpEqualityExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf relationalExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf equalityOpEqualityExpr_];}]) {
+        [PKParser_weakSelf equalityOpEqualityExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchEqualityExpr:)];
 }
 
 - (void)equalityOpEqualityExpr_ {
-    
-    [self equalityOperator_]; 
-    [self equalityExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf equalityOperator_];
+    [PKParser_weakSelf equalityExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchEqualityOpEqualityExpr:)];
 }
 
 - (void)relationalExpr_ {
-    
-    [self shiftExpr_]; 
-    while ([self speculate:^{ [self relationalOperator_]; [self shiftExpr_]; }]) {
-        [self relationalOperator_]; 
-        [self shiftExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf shiftExpr_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf relationalOperator_];[PKParser_weakSelf shiftExpr_];}]) {
+        [PKParser_weakSelf relationalOperator_];
+        [PKParser_weakSelf shiftExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchRelationalExpr:)];
 }
 
 - (void)shiftExpr_ {
-    
-    [self additiveExpr_]; 
-    if ([self speculate:^{ [self shiftOpShiftExpr_]; }]) {
-        [self shiftOpShiftExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf additiveExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf shiftOpShiftExpr_];}]) {
+        [PKParser_weakSelf shiftOpShiftExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchShiftExpr:)];
 }
 
 - (void)shiftOpShiftExpr_ {
-    
-    [self shiftOperator_]; 
-    [self shiftExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf shiftOperator_];
+    [PKParser_weakSelf shiftExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchShiftOpShiftExpr:)];
 }
 
 - (void)additiveExpr_ {
-    
-    [self multiplicativeExpr_]; 
-    if ([self speculate:^{ [self plusOrMinusExpr_]; }]) {
-        [self plusOrMinusExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf multiplicativeExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf plusOrMinusExpr_];}]) {
+        [PKParser_weakSelf plusOrMinusExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAdditiveExpr:)];
 }
 
 - (void)plusOrMinusExpr_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_PLUS, 0]) {
-        [self plusExpr_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_MINUS, 0]) {
-        [self minusExpr_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_PLUS, 0]) {
+        [PKParser_weakSelf plusExpr_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_MINUS, 0]) {
+        [PKParser_weakSelf minusExpr_];
     } else {
-        [self raise:@"No viable alternative found in rule 'plusOrMinusExpr'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'plusOrMinusExpr'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchPlusOrMinusExpr:)];
 }
 
 - (void)plusExpr_ {
-    
-    [self plus_]; 
-    [self additiveExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf plus_];
+    [PKParser_weakSelf additiveExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchPlusExpr:)];
 }
 
 - (void)minusExpr_ {
-    
-    [self minus_]; 
-    [self additiveExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf minus_];
+    [PKParser_weakSelf additiveExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchMinusExpr:)];
 }
 
 - (void)multiplicativeExpr_ {
-    
-    [self unaryExpr_]; 
-    if ([self speculate:^{ [self multiplicativeOperator_]; [self multiplicativeExpr_]; }]) {
-        [self multiplicativeOperator_]; 
-        [self multiplicativeExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf unaryExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf multiplicativeOperator_];[PKParser_weakSelf multiplicativeExpr_];}]) {
+        [PKParser_weakSelf multiplicativeOperator_];
+        [PKParser_weakSelf multiplicativeExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchMultiplicativeExpr:)];
 }
 
 - (void)unaryExpr_ {
-    
-    if ([self speculate:^{ [self memberExpr_]; }]) {
-        [self memberExpr_]; 
-    } else if ([self speculate:^{ [self unaryExpr1_]; }]) {
-        [self unaryExpr1_]; 
-    } else if ([self speculate:^{ [self unaryExpr2_]; }]) {
-        [self unaryExpr2_]; 
-    } else if ([self speculate:^{ [self unaryExpr3_]; }]) {
-        [self unaryExpr3_]; 
-    } else if ([self speculate:^{ [self unaryExpr4_]; }]) {
-        [self unaryExpr4_]; 
-    } else if ([self speculate:^{ [self unaryExpr6_]; }]) {
-        [self unaryExpr6_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf memberExpr_];}]) {
+        [PKParser_weakSelf memberExpr_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf unaryExpr1_];}]) {
+        [PKParser_weakSelf unaryExpr1_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf unaryExpr2_];}]) {
+        [PKParser_weakSelf unaryExpr2_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf unaryExpr3_];}]) {
+        [PKParser_weakSelf unaryExpr3_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf unaryExpr4_];}]) {
+        [PKParser_weakSelf unaryExpr4_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf unaryExpr6_];}]) {
+        [PKParser_weakSelf unaryExpr6_];
     } else {
-        [self raise:@"No viable alternative found in rule 'unaryExpr'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'unaryExpr'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchUnaryExpr:)];
 }
 
 - (void)unaryExpr1_ {
-    
-    [self unaryOperator_]; 
-    [self unaryExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf unaryOperator_];
+    [PKParser_weakSelf unaryExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchUnaryExpr1:)];
 }
 
 - (void)unaryExpr2_ {
-    
-    [self minus_]; 
-    [self unaryExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf minus_];
+    [PKParser_weakSelf unaryExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchUnaryExpr2:)];
 }
 
 - (void)unaryExpr3_ {
-    
-    [self incrementOperator_]; 
-    [self memberExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf incrementOperator_];
+    [PKParser_weakSelf memberExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchUnaryExpr3:)];
 }
 
 - (void)unaryExpr4_ {
-    
-    [self memberExpr_]; 
-    [self incrementOperator_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf memberExpr_];
+    [PKParser_weakSelf incrementOperator_];
 
     [self fireDelegateSelector:@selector(parser:didMatchUnaryExpr4:)];
 }
 
 - (void)callNewExpr_ {
-    
-    [self keywordNew_]; 
-    [self constructor_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf keywordNew_];
+    [PKParser_weakSelf constructor_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCallNewExpr:)];
 }
 
 - (void)unaryExpr6_ {
-    
-    [self delete_]; 
-    [self memberExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf delete_];
+    [PKParser_weakSelf memberExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchUnaryExpr6:)];
 }
 
 - (void)constructor_ {
-    
-    if ([self speculate:^{ [self this_]; [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_DOT block:^{ [self dot_]; } completion:^{ [self dot_]; }];}]) {
-        [self this_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf this_];[self tryAndRecover:JAVASCRIPT_TOKEN_KIND_DOT block:^{ [PKParser_weakSelf dot_];} completion:^{ [PKParser_weakSelf dot_];}];}]) {
+        [PKParser_weakSelf this_];
         [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_DOT block:^{ 
-            [self dot_]; 
+            [PKParser_weakSelf dot_];
         } completion:^{ 
-            [self dot_]; 
+            [PKParser_weakSelf dot_];
         }];
     }
-    [self constructorCall_]; 
+    [PKParser_weakSelf constructorCall_];
 
     [self fireDelegateSelector:@selector(parser:didMatchConstructor:)];
 }
 
 - (void)constructorCall_ {
-    
-    [self identifier_]; 
-    if ([self speculate:^{ if ([self predicts:JAVASCRIPT_TOKEN_KIND_OPENPAREN, 0]) {[self parenArgListParen_]; } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_DOT, 0]) {[self dot_]; [self constructorCall_]; } else {[self raise:@"No viable alternative found in rule 'constructorCall'."];}}]) {
-        if ([self predicts:JAVASCRIPT_TOKEN_KIND_OPENPAREN, 0]) {
-            [self parenArgListParen_]; 
-        } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_DOT, 0]) {
-            [self dot_]; 
-            [self constructorCall_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf identifier_];
+    if ([PKParser_weakSelf speculate:^{ if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_OPENPAREN, 0]) {[PKParser_weakSelf parenArgListParen_];} else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_DOT, 0]) {[PKParser_weakSelf dot_];[PKParser_weakSelf constructorCall_];} else {[PKParser_weakSelf raise:@"No viable alternative found in rule 'constructorCall'."];}}]) {
+        if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_OPENPAREN, 0]) {
+            [PKParser_weakSelf parenArgListParen_];
+        } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_DOT, 0]) {
+            [PKParser_weakSelf dot_];
+            [PKParser_weakSelf constructorCall_];
         } else {
-            [self raise:@"No viable alternative found in rule 'constructorCall'."];
+            [PKParser_weakSelf raise:@"No viable alternative found in rule 'constructorCall'."];
         }
     }
 
@@ -1575,163 +1577,163 @@
 }
 
 - (void)parenArgListParen_ {
-    
-    [self openParen_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf openParen_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_CLOSEPAREN block:^{ 
-        [self argListOpt_]; 
-        [self closeParen_]; 
+        [PKParser_weakSelf argListOpt_];
+        [PKParser_weakSelf closeParen_];
     } completion:^{ 
-        [self closeParen_]; 
+        [PKParser_weakSelf closeParen_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchParenArgListParen:)];
 }
 
 - (void)memberExpr_ {
-    
-    [self primaryExpr_]; 
-    if ([self speculate:^{ [self dotBracketOrParenExpr_]; }]) {
-        [self dotBracketOrParenExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf primaryExpr_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf dotBracketOrParenExpr_];}]) {
+        [PKParser_weakSelf dotBracketOrParenExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchMemberExpr:)];
 }
 
 - (void)dotBracketOrParenExpr_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_DOT, 0]) {
-        [self dotMemberExpr_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_OPENBRACKET, 0]) {
-        [self bracketMemberExpr_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_OPENPAREN, 0]) {
-        [self parenMemberExpr_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_DOT, 0]) {
+        [PKParser_weakSelf dotMemberExpr_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_OPENBRACKET, 0]) {
+        [PKParser_weakSelf bracketMemberExpr_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_OPENPAREN, 0]) {
+        [PKParser_weakSelf parenMemberExpr_];
     } else {
-        [self raise:@"No viable alternative found in rule 'dotBracketOrParenExpr'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'dotBracketOrParenExpr'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchDotBracketOrParenExpr:)];
 }
 
 - (void)dotMemberExpr_ {
-    
-    [self dot_]; 
-    [self memberExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf dot_];
+    [PKParser_weakSelf memberExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchDotMemberExpr:)];
 }
 
 - (void)bracketMemberExpr_ {
-    
-    [self openBracket_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf openBracket_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_CLOSEBRACKET block:^{ 
-        [self expr_]; 
-        [self closeBracket_]; 
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf closeBracket_];
     } completion:^{ 
-        [self closeBracket_]; 
+        [PKParser_weakSelf closeBracket_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchBracketMemberExpr:)];
 }
 
 - (void)parenMemberExpr_ {
-    
-    [self openParen_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf openParen_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_CLOSEPAREN block:^{ 
-        [self argListOpt_]; 
-        [self closeParen_]; 
+        [PKParser_weakSelf argListOpt_];
+        [PKParser_weakSelf closeParen_];
     } completion:^{ 
-        [self closeParen_]; 
+        [PKParser_weakSelf closeParen_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchParenMemberExpr:)];
 }
 
 - (void)argListOpt_ {
-    
-    if ([self speculate:^{ [self argList_]; }]) {
-        [self argList_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf argList_];}]) {
+        [PKParser_weakSelf argList_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchArgListOpt:)];
 }
 
 - (void)argList_ {
-    
-    [self assignmentExpr_]; 
-    while ([self speculate:^{ [self commaAssignmentExpr_]; }]) {
-        [self commaAssignmentExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf assignmentExpr_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf commaAssignmentExpr_];}]) {
+        [PKParser_weakSelf commaAssignmentExpr_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchArgList:)];
 }
 
 - (void)commaAssignmentExpr_ {
-    
-    [self comma_]; 
-    [self assignmentExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf comma_];
+    [PKParser_weakSelf assignmentExpr_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCommaAssignmentExpr:)];
 }
 
 - (void)primaryExpr_ {
-    
-    if ([self predicts:JAVASCRIPT_TOKEN_KIND_KEYWORDNEW, 0]) {
-        [self callNewExpr_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_OPENPAREN, 0]) {
-        [self parenExprParen_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self identifier_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
-        [self numLiteral_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self stringLiteral_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_FALSE, 0]) {
-        [self false_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_TRUE, 0]) {
-        [self true_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_NULL, 0]) {
-        [self null_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_UNDEFINED, 0]) {
-        [self undefined_]; 
-    } else if ([self predicts:JAVASCRIPT_TOKEN_KIND_THIS, 0]) {
-        [self this_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_KEYWORDNEW, 0]) {
+        [PKParser_weakSelf callNewExpr_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_OPENPAREN, 0]) {
+        [PKParser_weakSelf parenExprParen_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf identifier_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
+        [PKParser_weakSelf numLiteral_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf stringLiteral_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_FALSE, 0]) {
+        [PKParser_weakSelf false_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_TRUE, 0]) {
+        [PKParser_weakSelf true_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_NULL, 0]) {
+        [PKParser_weakSelf null_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_UNDEFINED, 0]) {
+        [PKParser_weakSelf undefined_];
+    } else if ([PKParser_weakSelf predicts:JAVASCRIPT_TOKEN_KIND_THIS, 0]) {
+        [PKParser_weakSelf this_];
     } else {
-        [self raise:@"No viable alternative found in rule 'primaryExpr'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'primaryExpr'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchPrimaryExpr:)];
 }
 
 - (void)parenExprParen_ {
-    
-    [self openParen_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf openParen_];
     [self tryAndRecover:JAVASCRIPT_TOKEN_KIND_CLOSEPAREN block:^{ 
-        [self expr_]; 
-        [self closeParen_]; 
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf closeParen_];
     } completion:^{ 
-        [self closeParen_]; 
+        [PKParser_weakSelf closeParen_];
     }];
 
     [self fireDelegateSelector:@selector(parser:didMatchParenExprParen:)];
 }
 
 - (void)identifier_ {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchIdentifier:)];
 }
 
 - (void)numLiteral_ {
-    
-    [self matchNumber:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNumLiteral:)];
 }
 
 - (void)stringLiteral_ {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchStringLiteral:)];
 }

--- a/test/LabelEBNFParser.m
+++ b/test/LabelEBNFParser.m
@@ -1,5 +1,6 @@
 #import "LabelEBNFParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface LabelEBNFParser ()
@@ -47,25 +48,26 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self s_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf s_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__s {
-    
-    if ([self speculate:^{ [self label_]; [self matchWord:NO]; [self match:LABELEBNF_TOKEN_KIND_EQUALS discard:NO]; [self expr_]; }]) {
-        [self label_]; 
-        [self matchWord:NO]; 
-        [self match:LABELEBNF_TOKEN_KIND_EQUALS discard:NO]; 
-        [self expr_]; 
-    } else if ([self speculate:^{ [self label_]; [self match:LABELEBNF_TOKEN_KIND_RETURN discard:NO]; [self expr_]; }]) {
-        [self label_]; 
-        [self match:LABELEBNF_TOKEN_KIND_RETURN discard:NO]; 
-        [self expr_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf label_];[PKParser_weakSelf matchWord:NO];[PKParser_weakSelf match:LABELEBNF_TOKEN_KIND_EQUALS discard:NO];[PKParser_weakSelf expr_];}]) {
+        [PKParser_weakSelf label_];
+        [PKParser_weakSelf matchWord:NO];
+        [PKParser_weakSelf match:LABELEBNF_TOKEN_KIND_EQUALS discard:NO];
+        [PKParser_weakSelf expr_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf label_];[PKParser_weakSelf match:LABELEBNF_TOKEN_KIND_RETURN discard:NO];[PKParser_weakSelf expr_];}]) {
+        [PKParser_weakSelf label_];
+        [PKParser_weakSelf match:LABELEBNF_TOKEN_KIND_RETURN discard:NO];
+        [PKParser_weakSelf expr_];
     } else {
-        [self raise:@"No viable alternative found in rule 's'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 's'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchS:)];
@@ -76,10 +78,10 @@
 }
 
 - (void)__label {
-    
-    while ([self speculate:^{ [self matchWord:NO]; [self match:LABELEBNF_TOKEN_KIND_COLON discard:NO]; }]) {
-        [self matchWord:NO]; 
-        [self match:LABELEBNF_TOKEN_KIND_COLON discard:NO]; 
+    PKParser_weakSelfDecl;
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf matchWord:NO];[PKParser_weakSelf match:LABELEBNF_TOKEN_KIND_COLON discard:NO];}]) {
+        [PKParser_weakSelf matchWord:NO];
+        [PKParser_weakSelf match:LABELEBNF_TOKEN_KIND_COLON discard:NO];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchLabel:)];
@@ -90,8 +92,8 @@
 }
 
 - (void)__expr {
-    
-    [self matchNumber:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchExpr:)];
 }

--- a/test/LabelRecursiveParser.m
+++ b/test/LabelRecursiveParser.m
@@ -1,5 +1,6 @@
 #import "LabelRecursiveParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface LabelRecursiveParser ()
@@ -47,25 +48,26 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self s_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf s_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__s {
-    
-    if ([self speculate:^{ [self label_]; [self matchWord:NO]; [self match:LABELRECURSIVE_TOKEN_KIND_EQUALS discard:NO]; [self expr_]; }]) {
-        [self label_]; 
-        [self matchWord:NO]; 
-        [self match:LABELRECURSIVE_TOKEN_KIND_EQUALS discard:NO]; 
-        [self expr_]; 
-    } else if ([self speculate:^{ [self label_]; [self match:LABELRECURSIVE_TOKEN_KIND_RETURN discard:NO]; [self expr_]; }]) {
-        [self label_]; 
-        [self match:LABELRECURSIVE_TOKEN_KIND_RETURN discard:NO]; 
-        [self expr_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf label_];[PKParser_weakSelf matchWord:NO];[PKParser_weakSelf match:LABELRECURSIVE_TOKEN_KIND_EQUALS discard:NO];[PKParser_weakSelf expr_];}]) {
+        [PKParser_weakSelf label_];
+        [PKParser_weakSelf matchWord:NO];
+        [PKParser_weakSelf match:LABELRECURSIVE_TOKEN_KIND_EQUALS discard:NO];
+        [PKParser_weakSelf expr_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf label_];[PKParser_weakSelf match:LABELRECURSIVE_TOKEN_KIND_RETURN discard:NO];[PKParser_weakSelf expr_];}]) {
+        [PKParser_weakSelf label_];
+        [PKParser_weakSelf match:LABELRECURSIVE_TOKEN_KIND_RETURN discard:NO];
+        [PKParser_weakSelf expr_];
     } else {
-        [self raise:@"No viable alternative found in rule 's'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 's'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchS:)];
@@ -76,11 +78,11 @@
 }
 
 - (void)__label {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self matchWord:NO]; 
-        [self match:LABELRECURSIVE_TOKEN_KIND_COLON discard:NO]; 
-        [self label_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf matchWord:NO];
+        [PKParser_weakSelf match:LABELRECURSIVE_TOKEN_KIND_COLON discard:NO];
+        [PKParser_weakSelf label_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchLabel:)];
@@ -91,8 +93,8 @@
 }
 
 - (void)__expr {
-    
-    [self matchNumber:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchExpr:)];
 }

--- a/test/Lines2Parser.m
+++ b/test/Lines2Parser.m
@@ -1,5 +1,6 @@
 #import "Lines2Parser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface Lines2Parser ()
@@ -30,7 +31,8 @@
 }
 
 - (void)start {
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
     PKTokenizer *t = self.tokenizer;
 
@@ -41,23 +43,23 @@
 
     }];
 
-    [self lines_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf lines_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)lines_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self line_]; 
-    } while ([self speculate:^{ [self line_]; }]);
+        [PKParser_weakSelf line_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf line_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchLines:)];
 }
 
 - (void)line_ {
-    
-    while ([self speculate:^{ if (![self predicts:LINES2_TOKEN_KIND__N, 0] && ![self predicts:LINES2_TOKEN_KIND__R, 0]) {[self match:TOKEN_KIND_BUILTIN_ANY discard:NO];} else {[self raise:@"negation test failed in line"];}}]) {
+    PKParser_weakSelfDecl;
+    while ([PKParser_weakSelf speculate:^{ if (![self predicts:LINES2_TOKEN_KIND__N, 0] && ![self predicts:LINES2_TOKEN_KIND__R, 0]) {[self match:TOKEN_KIND_BUILTIN_ANY discard:NO];} else {[self raise:@"negation test failed in line"];}}]) {
         if (![self predicts:LINES2_TOKEN_KIND__N, 0] && ![self predicts:LINES2_TOKEN_KIND__R, 0]) {
             [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
         } else {
@@ -65,20 +67,20 @@
         }
     }
     do {
-        [self eol_]; 
+        [PKParser_weakSelf eol_];
     } while ([self predicts:LINES2_TOKEN_KIND__N, LINES2_TOKEN_KIND__R, 0]);
 
     [self fireDelegateSelector:@selector(parser:didMatchLine:)];
 }
 
 - (void)eol_ {
-    
-    if ([self predicts:LINES2_TOKEN_KIND__N, 0]) {
-        [self match:LINES2_TOKEN_KIND__N discard:YES]; 
-    } else if ([self predicts:LINES2_TOKEN_KIND__R, 0]) {
-        [self match:LINES2_TOKEN_KIND__R discard:YES]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:LINES2_TOKEN_KIND__N, 0]) {
+        [PKParser_weakSelf match:LINES2_TOKEN_KIND__N discard:YES];
+    } else if ([PKParser_weakSelf predicts:LINES2_TOKEN_KIND__R, 0]) {
+        [PKParser_weakSelf match:LINES2_TOKEN_KIND__R discard:YES];
     } else {
-        [self raise:@"No viable alternative found in rule 'eol'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'eol'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchEol:)];

--- a/test/LinesParser.m
+++ b/test/LinesParser.m
@@ -1,5 +1,6 @@
 #import "LinesParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface LinesParser ()
@@ -26,7 +27,8 @@
 }
 
 - (void)start {
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
     PKTokenizer *t = self.tokenizer;
 
@@ -40,38 +42,38 @@
 
     }];
 
-    [self lines_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf lines_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)lines_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self line_]; 
-    } while ([self speculate:^{ [self line_]; }]);
+        [PKParser_weakSelf line_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf line_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchLines:)];
 }
 
 - (void)line_ {
-    
-    while ([self speculate:^{ if (![self speculate:^{ [self eol_]; }]) {[self match:TOKEN_KIND_BUILTIN_ANY discard:NO];} else {[self raise:@"negation test failed in line"];}}]) {
-        if (![self speculate:^{ [self eol_]; }]) {
-            [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
+    PKParser_weakSelfDecl;
+    while ([PKParser_weakSelf speculate:^{ if (![PKParser_weakSelf speculate:^{ [PKParser_weakSelf eol_];}]) {[PKParser_weakSelf match:TOKEN_KIND_BUILTIN_ANY discard:NO];} else {[PKParser_weakSelf raise:@"negation test failed in line"];}}]) {
+        if (![PKParser_weakSelf speculate:^{ [PKParser_weakSelf eol_];}]) {
+            [PKParser_weakSelf match:TOKEN_KIND_BUILTIN_ANY discard:NO];
         } else {
-            [self raise:@"negation test failed in line"];
+            [PKParser_weakSelf raise:@"negation test failed in line"];
         }
     }
-    [self eol_]; 
+    [PKParser_weakSelf eol_];
 
     [self fireDelegateSelector:@selector(parser:didMatchLine:)];
 }
 
 - (void)eol_ {
-    
+    PKParser_weakSelfDecl;
     [self testAndThrow:(id)^{ return EQ(@"\n", LS(1)); }]; 
-    [self matchWhitespace:NO]; 
+    [PKParser_weakSelf matchWhitespace:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchEol:)];
 }

--- a/test/MethodsFactoredParser.m
+++ b/test/MethodsFactoredParser.m
@@ -1,5 +1,6 @@
 #import "MethodsFactoredParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface MethodsFactoredParser ()
@@ -65,17 +66,18 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__start {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self method_]; 
-    } while ([self speculate:^{ [self method_]; }]);
+        [PKParser_weakSelf method_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf method_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
@@ -85,19 +87,19 @@
 }
 
 - (void)__method {
-    
-    [self type_]; 
-    [self matchWord:NO]; 
-    [self match:METHODSFACTORED_TOKEN_KIND_OPEN_PAREN discard:NO]; 
-    [self args_]; 
-    [self match:METHODSFACTORED_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
-    if ([self predicts:METHODSFACTORED_TOKEN_KIND_SEMI_COLON, 0]) {
-        [self match:METHODSFACTORED_TOKEN_KIND_SEMI_COLON discard:NO]; 
-    } else if ([self predicts:METHODSFACTORED_TOKEN_KIND_OPEN_CURLY, 0]) {
-        [self match:METHODSFACTORED_TOKEN_KIND_OPEN_CURLY discard:NO]; 
-        [self match:METHODSFACTORED_TOKEN_KIND_CLOSE_CURLY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf type_];
+    [PKParser_weakSelf matchWord:NO];
+    [PKParser_weakSelf match:METHODSFACTORED_TOKEN_KIND_OPEN_PAREN discard:NO];
+    [PKParser_weakSelf args_];
+    [PKParser_weakSelf match:METHODSFACTORED_TOKEN_KIND_CLOSE_PAREN discard:NO];
+    if ([PKParser_weakSelf predicts:METHODSFACTORED_TOKEN_KIND_SEMI_COLON, 0]) {
+        [PKParser_weakSelf match:METHODSFACTORED_TOKEN_KIND_SEMI_COLON discard:NO];
+    } else if ([PKParser_weakSelf predicts:METHODSFACTORED_TOKEN_KIND_OPEN_CURLY, 0]) {
+        [PKParser_weakSelf match:METHODSFACTORED_TOKEN_KIND_OPEN_CURLY discard:NO];
+        [PKParser_weakSelf match:METHODSFACTORED_TOKEN_KIND_CLOSE_CURLY discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'method'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'method'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchMethod:)];
@@ -108,13 +110,13 @@
 }
 
 - (void)__type {
-    
-    if ([self predicts:METHODSFACTORED_TOKEN_KIND_VOID, 0]) {
-        [self match:METHODSFACTORED_TOKEN_KIND_VOID discard:NO]; 
-    } else if ([self predicts:METHODSFACTORED_TOKEN_KIND_INT, 0]) {
-        [self match:METHODSFACTORED_TOKEN_KIND_INT discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:METHODSFACTORED_TOKEN_KIND_VOID, 0]) {
+        [PKParser_weakSelf match:METHODSFACTORED_TOKEN_KIND_VOID discard:NO];
+    } else if ([PKParser_weakSelf predicts:METHODSFACTORED_TOKEN_KIND_INT, 0]) {
+        [PKParser_weakSelf match:METHODSFACTORED_TOKEN_KIND_INT discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'type'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'type'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchType:)];
@@ -125,12 +127,12 @@
 }
 
 - (void)__args {
-    
-    if ([self predicts:METHODSFACTORED_TOKEN_KIND_INT, 0]) {
-        [self arg_]; 
-        while ([self speculate:^{ [self match:METHODSFACTORED_TOKEN_KIND_COMMA discard:NO]; [self arg_]; }]) {
-            [self match:METHODSFACTORED_TOKEN_KIND_COMMA discard:NO]; 
-            [self arg_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:METHODSFACTORED_TOKEN_KIND_INT, 0]) {
+        [PKParser_weakSelf arg_];
+        while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:METHODSFACTORED_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf arg_];}]) {
+            [PKParser_weakSelf match:METHODSFACTORED_TOKEN_KIND_COMMA discard:NO];
+            [PKParser_weakSelf arg_];
         }
     }
 
@@ -142,9 +144,9 @@
 }
 
 - (void)__arg {
-    
-    [self match:METHODSFACTORED_TOKEN_KIND_INT discard:NO]; 
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:METHODSFACTORED_TOKEN_KIND_INT discard:NO];
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchArg:)];
 }

--- a/test/MethodsParser.m
+++ b/test/MethodsParser.m
@@ -1,5 +1,6 @@
 #import "MethodsParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface MethodsParser ()
@@ -65,17 +66,18 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__start {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self method_]; 
-    } while ([self speculate:^{ [self method_]; }]);
+        [PKParser_weakSelf method_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf method_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
@@ -85,26 +87,26 @@
 }
 
 - (void)__method {
-    
-    if ([self speculate:^{ [self testAndThrow:(id)^{ return NO; }]; [self type_]; [self matchWord:NO]; [self match:METHODS_TOKEN_KIND_OPEN_PAREN discard:NO]; [self args_]; [self match:METHODS_TOKEN_KIND_CLOSE_PAREN discard:NO]; [self match:METHODS_TOKEN_KIND_SEMI_COLON discard:NO]; }]) {
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [self testAndThrow:(id)^{ return NO; }]; [PKParser_weakSelf type_];[PKParser_weakSelf matchWord:NO];[PKParser_weakSelf match:METHODS_TOKEN_KIND_OPEN_PAREN discard:NO];[PKParser_weakSelf args_];[PKParser_weakSelf match:METHODS_TOKEN_KIND_CLOSE_PAREN discard:NO];[PKParser_weakSelf match:METHODS_TOKEN_KIND_SEMI_COLON discard:NO];}]) {
         [self testAndThrow:(id)^{ return NO; }]; 
-        [self type_]; 
-        [self matchWord:NO]; 
-        [self match:METHODS_TOKEN_KIND_OPEN_PAREN discard:NO]; 
-        [self args_]; 
-        [self match:METHODS_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
-        [self match:METHODS_TOKEN_KIND_SEMI_COLON discard:NO]; 
-    } else if ([self speculate:^{ [self testAndThrow:(id)^{ return 1; }]; [self type_]; [self matchWord:NO]; [self match:METHODS_TOKEN_KIND_OPEN_PAREN discard:NO]; [self args_]; [self match:METHODS_TOKEN_KIND_CLOSE_PAREN discard:NO]; [self match:METHODS_TOKEN_KIND_OPEN_CURLY discard:NO]; [self match:METHODS_TOKEN_KIND_CLOSE_CURLY discard:NO]; }]) {
+        [PKParser_weakSelf type_];
+        [PKParser_weakSelf matchWord:NO];
+        [PKParser_weakSelf match:METHODS_TOKEN_KIND_OPEN_PAREN discard:NO];
+        [PKParser_weakSelf args_];
+        [PKParser_weakSelf match:METHODS_TOKEN_KIND_CLOSE_PAREN discard:NO];
+        [PKParser_weakSelf match:METHODS_TOKEN_KIND_SEMI_COLON discard:NO];
+    } else if ([PKParser_weakSelf speculate:^{ [self testAndThrow:(id)^{ return 1; }]; [PKParser_weakSelf type_];[PKParser_weakSelf matchWord:NO];[PKParser_weakSelf match:METHODS_TOKEN_KIND_OPEN_PAREN discard:NO];[PKParser_weakSelf args_];[PKParser_weakSelf match:METHODS_TOKEN_KIND_CLOSE_PAREN discard:NO];[PKParser_weakSelf match:METHODS_TOKEN_KIND_OPEN_CURLY discard:NO];[PKParser_weakSelf match:METHODS_TOKEN_KIND_CLOSE_CURLY discard:NO];}]) {
         [self testAndThrow:(id)^{ return 1; }]; 
-        [self type_]; 
-        [self matchWord:NO]; 
-        [self match:METHODS_TOKEN_KIND_OPEN_PAREN discard:NO]; 
-        [self args_]; 
-        [self match:METHODS_TOKEN_KIND_CLOSE_PAREN discard:NO]; 
-        [self match:METHODS_TOKEN_KIND_OPEN_CURLY discard:NO]; 
-        [self match:METHODS_TOKEN_KIND_CLOSE_CURLY discard:NO]; 
+        [PKParser_weakSelf type_];
+        [PKParser_weakSelf matchWord:NO];
+        [PKParser_weakSelf match:METHODS_TOKEN_KIND_OPEN_PAREN discard:NO];
+        [PKParser_weakSelf args_];
+        [PKParser_weakSelf match:METHODS_TOKEN_KIND_CLOSE_PAREN discard:NO];
+        [PKParser_weakSelf match:METHODS_TOKEN_KIND_OPEN_CURLY discard:NO];
+        [PKParser_weakSelf match:METHODS_TOKEN_KIND_CLOSE_CURLY discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'method'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'method'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchMethod:)];
@@ -115,13 +117,13 @@
 }
 
 - (void)__type {
-    
-    if ([self predicts:METHODS_TOKEN_KIND_VOID, 0]) {
-        [self match:METHODS_TOKEN_KIND_VOID discard:NO]; 
-    } else if ([self predicts:METHODS_TOKEN_KIND_INT, 0]) {
-        [self match:METHODS_TOKEN_KIND_INT discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:METHODS_TOKEN_KIND_VOID, 0]) {
+        [PKParser_weakSelf match:METHODS_TOKEN_KIND_VOID discard:NO];
+    } else if ([PKParser_weakSelf predicts:METHODS_TOKEN_KIND_INT, 0]) {
+        [PKParser_weakSelf match:METHODS_TOKEN_KIND_INT discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'type'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'type'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchType:)];
@@ -132,12 +134,12 @@
 }
 
 - (void)__args {
-    
-    if ([self predicts:METHODS_TOKEN_KIND_INT, 0]) {
-        [self arg_]; 
-        while ([self speculate:^{ [self match:METHODS_TOKEN_KIND_COMMA discard:NO]; [self arg_]; }]) {
-            [self match:METHODS_TOKEN_KIND_COMMA discard:NO]; 
-            [self arg_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:METHODS_TOKEN_KIND_INT, 0]) {
+        [PKParser_weakSelf arg_];
+        while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:METHODS_TOKEN_KIND_COMMA discard:NO];[PKParser_weakSelf arg_];}]) {
+            [PKParser_weakSelf match:METHODS_TOKEN_KIND_COMMA discard:NO];
+            [PKParser_weakSelf arg_];
         }
     }
 
@@ -149,9 +151,9 @@
 }
 
 - (void)__arg {
-    
-    [self match:METHODS_TOKEN_KIND_INT discard:NO]; 
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:METHODS_TOKEN_KIND_INT discard:NO];
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchArg:)];
 }

--- a/test/MiniMath2Parser.m
+++ b/test/MiniMath2Parser.m
@@ -1,5 +1,6 @@
 #import "MiniMath2Parser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface MiniMath2Parser ()
@@ -34,25 +35,26 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self expr_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf expr_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)expr_ {
-    
-    [self addExpr_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf addExpr_];
 
 }
 
 - (void)addExpr_ {
-    
-    [self multExpr_]; 
-    while ([self speculate:^{ [self match:MINIMATH2_TOKEN_KIND_PLUS discard:YES]; [self multExpr_]; }]) {
-        [self match:MINIMATH2_TOKEN_KIND_PLUS discard:YES]; 
-        [self multExpr_]; 
-        [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf multExpr_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:MINIMATH2_TOKEN_KIND_PLUS discard:YES];[PKParser_weakSelf multExpr_];}]) {
+        [PKParser_weakSelf match:MINIMATH2_TOKEN_KIND_PLUS discard:YES];
+        [PKParser_weakSelf multExpr_];
+        [PKParser_weakSelf execute:^{
         
     PUSH_DOUBLE(POP_DOUBLE() + POP_DOUBLE());
 
@@ -62,12 +64,12 @@
 }
 
 - (void)multExpr_ {
-    
-    [self primary_]; 
-    while ([self speculate:^{ [self match:MINIMATH2_TOKEN_KIND_STAR discard:YES]; [self primary_]; }]) {
-        [self match:MINIMATH2_TOKEN_KIND_STAR discard:YES]; 
-        [self primary_]; 
-        [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf primary_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:MINIMATH2_TOKEN_KIND_STAR discard:YES];[PKParser_weakSelf primary_];}]) {
+        [PKParser_weakSelf match:MINIMATH2_TOKEN_KIND_STAR discard:YES];
+        [PKParser_weakSelf primary_];
+        [PKParser_weakSelf execute:^{
          
     PUSH_DOUBLE(POP_DOUBLE() * POP_DOUBLE());
 
@@ -77,23 +79,23 @@
 }
 
 - (void)primary_ {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
-        [self atom_]; 
-    } else if ([self predicts:MINIMATH2_TOKEN_KIND_OPEN_PAREN, 0]) {
-        [self match:MINIMATH2_TOKEN_KIND_OPEN_PAREN discard:YES]; 
-        [self expr_]; 
-        [self match:MINIMATH2_TOKEN_KIND_CLOSE_PAREN discard:YES]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
+        [PKParser_weakSelf atom_];
+    } else if ([PKParser_weakSelf predicts:MINIMATH2_TOKEN_KIND_OPEN_PAREN, 0]) {
+        [PKParser_weakSelf match:MINIMATH2_TOKEN_KIND_OPEN_PAREN discard:YES];
+        [PKParser_weakSelf expr_];
+        [PKParser_weakSelf match:MINIMATH2_TOKEN_KIND_CLOSE_PAREN discard:YES];
     } else {
-        [self raise:@"No viable alternative found in rule 'primary'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'primary'."];
     }
 
 }
 
 - (void)atom_ {
-    
-    [self matchNumber:NO]; 
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
+    [PKParser_weakSelf execute:^{
      
     PUSH_DOUBLE(POP_DOUBLE()); 
 

--- a/test/MiniMathParser.m
+++ b/test/MiniMathParser.m
@@ -1,5 +1,6 @@
 #import "MiniMathParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface MiniMathParser ()
@@ -51,19 +52,20 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self expr_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf expr_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__expr {
-    
-    [self mult_]; 
-    while ([self speculate:^{ [self match:MINIMATH_TOKEN_KIND_PLUS discard:YES]; [self mult_]; }]) {
-        [self match:MINIMATH_TOKEN_KIND_PLUS discard:YES]; 
-        [self mult_]; 
-        [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf mult_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:MINIMATH_TOKEN_KIND_PLUS discard:YES];[PKParser_weakSelf mult_];}]) {
+        [PKParser_weakSelf match:MINIMATH_TOKEN_KIND_PLUS discard:YES];
+        [PKParser_weakSelf mult_];
+        [PKParser_weakSelf execute:^{
          PUSH_DOUBLE(POP_DOUBLE()+POP_DOUBLE()); 
         }];
     }
@@ -76,12 +78,12 @@
 }
 
 - (void)__mult {
-    
-    [self pow_]; 
-    while ([self speculate:^{ [self match:MINIMATH_TOKEN_KIND_STAR discard:YES]; [self pow_]; }]) {
-        [self match:MINIMATH_TOKEN_KIND_STAR discard:YES]; 
-        [self pow_]; 
-        [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf pow_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:MINIMATH_TOKEN_KIND_STAR discard:YES];[PKParser_weakSelf pow_];}]) {
+        [PKParser_weakSelf match:MINIMATH_TOKEN_KIND_STAR discard:YES];
+        [PKParser_weakSelf pow_];
+        [PKParser_weakSelf execute:^{
          PUSH_DOUBLE(POP_DOUBLE()*POP_DOUBLE()); 
         }];
     }
@@ -94,12 +96,12 @@
 }
 
 - (void)__pow {
-    
-    [self atom_]; 
-    if ([self speculate:^{ [self match:MINIMATH_TOKEN_KIND_CARET discard:YES]; [self pow_]; }]) {
-        [self match:MINIMATH_TOKEN_KIND_CARET discard:YES]; 
-        [self pow_]; 
-        [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf atom_];
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:MINIMATH_TOKEN_KIND_CARET discard:YES];[PKParser_weakSelf pow_];}]) {
+        [PKParser_weakSelf match:MINIMATH_TOKEN_KIND_CARET discard:YES];
+        [PKParser_weakSelf pow_];
+        [PKParser_weakSelf execute:^{
          
 		double exp = POP_DOUBLE();
 		double base = POP_DOUBLE();
@@ -119,9 +121,9 @@
 }
 
 - (void)__atom {
-    
-    [self matchNumber:NO]; 
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
+    [PKParser_weakSelf execute:^{
     PUSH_DOUBLE(POP_DOUBLE());
     }];
 

--- a/test/MultipleParser.m
+++ b/test/MultipleParser.m
@@ -1,5 +1,6 @@
 #import "MultipleParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface MultipleParser ()
@@ -49,18 +50,19 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self s_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf s_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__s {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self ab_]; 
-    } while ([self speculate:^{ [self ab_]; }]);
-    [self a_]; 
+        [PKParser_weakSelf ab_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf ab_];}]);
+    [PKParser_weakSelf a_];
 
     [self fireDelegateSelector:@selector(parser:didMatchS:)];
 }
@@ -70,9 +72,9 @@
 }
 
 - (void)__ab {
-    
-    [self a_]; 
-    [self b_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf a_];
+    [PKParser_weakSelf b_];
 
     [self fireDelegateSelector:@selector(parser:didMatchAb:)];
 }
@@ -82,8 +84,8 @@
 }
 
 - (void)__a {
-    
-    [self match:MULTIPLE_TOKEN_KIND_A discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:MULTIPLE_TOKEN_KIND_A discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchA:)];
 }
@@ -93,8 +95,8 @@
 }
 
 - (void)__b {
-    
-    [self match:MULTIPLE_TOKEN_KIND_B discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:MULTIPLE_TOKEN_KIND_B discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchB:)];
 }

--- a/test/NamedActionParser.m
+++ b/test/NamedActionParser.m
@@ -1,5 +1,6 @@
 #import "NamedActionParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface NamedActionParser ()
@@ -45,16 +46,17 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__start {
-    
-    [self a_]; 
-    [self b_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf a_];
+    [PKParser_weakSelf b_];
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
@@ -64,12 +66,12 @@
 }
 
 - (void)__a {
-    
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     PUSH(@"foo");
     }];
-    [self match:NAMEDACTION_TOKEN_KIND_A discard:NO]; 
-    [self execute:^{
+    [PKParser_weakSelf match:NAMEDACTION_TOKEN_KIND_A discard:NO];
+    [PKParser_weakSelf execute:^{
     PUSH(@"bar");
     }];
 
@@ -81,8 +83,8 @@
 }
 
 - (void)__b {
-    
-    [self match:NAMEDACTION_TOKEN_KIND_B discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:NAMEDACTION_TOKEN_KIND_B discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchB:)];
 }

--- a/test/Negation2Parser.m
+++ b/test/Negation2Parser.m
@@ -1,5 +1,6 @@
 #import "Negation2Parser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface Negation2Parser ()
@@ -30,7 +31,8 @@
 }
 
 - (void)start {
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
         PKTokenizer *t = self.tokenizer;
 
@@ -40,35 +42,35 @@
 
     }];
 
-    [self document_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf document_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)document_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self any_]; 
-    } while ([self speculate:^{ [self any_]; }]);
+        [PKParser_weakSelf any_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf any_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchDocument:)];
 }
 
 - (void)any_ {
-    
-    if ([self speculate:^{ [self tag_]; }]) {
-        [self tag_]; 
-    } else if ([self speculate:^{ [self text_]; }]) {
-        [self text_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf tag_];}]) {
+        [PKParser_weakSelf tag_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf text_];}]) {
+        [PKParser_weakSelf text_];
     } else {
-        [self raise:@"No viable alternative found in rule 'any'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'any'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAny:)];
 }
 
 - (void)text_ {
-    
+    PKParser_weakSelfDecl;
     if (![self predicts:NEGATION2_TOKEN_KIND_TAGSTART, 0]) {
         [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
     } else {
@@ -79,32 +81,32 @@
 }
 
 - (void)tag_ {
-    
-    [self tagStart_]; 
-    while ([self speculate:^{ [self tagContent_]; }]) {
-        [self tagContent_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf tagStart_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf tagContent_];}]) {
+        [PKParser_weakSelf tagContent_];
     }
-    [self tagEnd_]; 
+    [PKParser_weakSelf tagEnd_];
 
     [self fireDelegateSelector:@selector(parser:didMatchTag:)];
 }
 
 - (void)tagStart_ {
-    
-    [self match:NEGATION2_TOKEN_KIND_TAGSTART discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:NEGATION2_TOKEN_KIND_TAGSTART discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTagStart:)];
 }
 
 - (void)tagEnd_ {
-    
-    [self match:NEGATION2_TOKEN_KIND_TAGEND discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:NEGATION2_TOKEN_KIND_TAGEND discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTagEnd:)];
 }
 
 - (void)tagContent_ {
-    
+    PKParser_weakSelfDecl;
     if (![self predicts:NEGATION2_TOKEN_KIND_TAGEND, 0]) {
         [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
     } else {

--- a/test/Negation3Parser.m
+++ b/test/Negation3Parser.m
@@ -1,5 +1,6 @@
 #import "Negation3Parser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface Negation3Parser ()
@@ -32,7 +33,8 @@
 }
 
 - (void)start {
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
         PKTokenizer *t = self.tokenizer;
 
@@ -42,35 +44,35 @@
 
     }];
 
-    [self document_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf document_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)document_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self any_]; 
-    } while ([self speculate:^{ [self any_]; }]);
+        [PKParser_weakSelf any_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf any_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchDocument:)];
 }
 
 - (void)any_ {
-    
-    if ([self speculate:^{ [self tag_]; }]) {
-        [self tag_]; 
-    } else if ([self speculate:^{ [self text_]; }]) {
-        [self text_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf tag_];}]) {
+        [PKParser_weakSelf tag_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf text_];}]) {
+        [PKParser_weakSelf text_];
     } else {
-        [self raise:@"No viable alternative found in rule 'any'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'any'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAny:)];
 }
 
 - (void)text_ {
-    
+    PKParser_weakSelfDecl;
     if (![self predicts:NEGATION3_TOKEN_KIND_TAGSTART, 0]) {
         [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
     } else {
@@ -81,50 +83,50 @@
 }
 
 - (void)tag_ {
-    
-    [self tagStart_]; 
-    while ([self speculate:^{ [self tagContent_]; }]) {
-        [self tagContent_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf tagStart_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf tagContent_];}]) {
+        [PKParser_weakSelf tagContent_];
     }
-    [self tagEnd_]; 
+    [PKParser_weakSelf tagEnd_];
 
     [self fireDelegateSelector:@selector(parser:didMatchTag:)];
 }
 
 - (void)tagStart_ {
-    
-    [self match:NEGATION3_TOKEN_KIND_TAGSTART discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:NEGATION3_TOKEN_KIND_TAGSTART discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTagStart:)];
 }
 
 - (void)tagEnd_ {
-    
-    [self match:NEGATION3_TOKEN_KIND_TAGEND discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:NEGATION3_TOKEN_KIND_TAGEND discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTagEnd:)];
 }
 
 - (void)tagContent_ {
-    
-    if ([self predicts:NEGATION3_TOKEN_KIND_IN, 0]) {
-        [self in_]; 
-    } else if (![self predicts:NEGATION3_TOKEN_KIND_TAGEND, 0]) {
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:NEGATION3_TOKEN_KIND_IN, 0]) {
+        [PKParser_weakSelf in_];
+    } else if (![PKParser_weakSelf predicts:NEGATION3_TOKEN_KIND_TAGEND, 0]) {
         if (![self predicts:NEGATION3_TOKEN_KIND_TAGEND, 0]) {
             [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
         } else {
             [self raise:@"negation test failed in tagContent"];
         }
     } else {
-        [self raise:@"No viable alternative found in rule 'tagContent'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'tagContent'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchTagContent:)];
 }
 
 - (void)in_ {
-    
-    [self match:NEGATION3_TOKEN_KIND_IN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:NEGATION3_TOKEN_KIND_IN discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchIn:)];
 }

--- a/test/NegationParser.m
+++ b/test/NegationParser.m
@@ -1,5 +1,6 @@
 #import "NegationParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface NegationParser ()
@@ -39,14 +40,15 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self s_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf s_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__s {
-    
+    PKParser_weakSelfDecl;
     if (![self predicts:NEGATION_TOKEN_KIND_FOO, 0]) {
         [self match:TOKEN_KIND_BUILTIN_ANY discard:NO];
     } else {
@@ -61,8 +63,8 @@
 }
 
 - (void)__foo {
-    
-    [self match:NEGATION_TOKEN_KIND_FOO discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:NEGATION_TOKEN_KIND_FOO discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchFoo:)];
 }

--- a/test/NondeterministicPalindromeParser.m
+++ b/test/NondeterministicPalindromeParser.m
@@ -1,5 +1,6 @@
 #import "NondeterministicPalindromeParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface NondeterministicPalindromeParser ()
@@ -30,28 +31,29 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self s_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf s_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)s_ {
-    
-    if ([self speculate:^{ [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO]; [self s_]; [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO]; }]) {
-        [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO]; 
-        [self s_]; 
-        [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO]; 
-    } else if ([self speculate:^{ [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO]; [self s_]; [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO]; }]) {
-        [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO]; 
-        [self s_]; 
-        [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO]; 
-    } else if ([self speculate:^{ [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO]; }]) {
-        [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO]; 
-    } else if ([self speculate:^{ [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO]; }]) {
-        [self match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO];[PKParser_weakSelf s_];[PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO];}]) {
+        [PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO];
+        [PKParser_weakSelf s_];
+        [PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO];[PKParser_weakSelf s_];[PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO];}]) {
+        [PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO];
+        [PKParser_weakSelf s_];
+        [PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO];}]) {
+        [PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_0 discard:NO];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO];}]) {
+        [PKParser_weakSelf match:NONDETERMINISTICPALINDROME_TOKEN_KIND_1 discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 's'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 's'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchS:)];

--- a/test/OptionalParser.m
+++ b/test/OptionalParser.m
@@ -1,5 +1,6 @@
 #import "OptionalParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface OptionalParser ()
@@ -49,19 +50,20 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self s_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf s_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__s {
-    
-    if ([self speculate:^{ [self expr_]; }]) {
-        [self expr_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf expr_];}]) {
+        [PKParser_weakSelf expr_];
     }
-    [self foo_]; 
-    [self bar_]; 
+    [PKParser_weakSelf foo_];
+    [PKParser_weakSelf bar_];
 
     [self fireDelegateSelector:@selector(parser:didMatchS:)];
 }
@@ -71,10 +73,10 @@
 }
 
 - (void)__expr {
-    
-    [self foo_]; 
-    [self bar_]; 
-    [self bar_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf foo_];
+    [PKParser_weakSelf bar_];
+    [PKParser_weakSelf bar_];
 
     [self fireDelegateSelector:@selector(parser:didMatchExpr:)];
 }
@@ -84,8 +86,8 @@
 }
 
 - (void)__foo {
-    
-    [self match:OPTIONAL_TOKEN_KIND_FOO discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:OPTIONAL_TOKEN_KIND_FOO discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchFoo:)];
 }
@@ -95,8 +97,8 @@
 }
 
 - (void)__bar {
-    
-    [self match:OPTIONAL_TOKEN_KIND_BAR discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:OPTIONAL_TOKEN_KIND_BAR discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchBar:)];
 }

--- a/test/QuoteSymbolParser.m
+++ b/test/QuoteSymbolParser.m
@@ -1,5 +1,6 @@
 #import "QuoteSymbolParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface QuoteSymbolParser ()
@@ -32,7 +33,8 @@
 }
 
 - (void)start {
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
     PKTokenizer *t = self.tokenizer;
 	[t setTokenizerState:t.symbolState from:'"' to:'"'];
@@ -40,52 +42,52 @@
 
     }];
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)start_ {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self sym_]; 
+        [PKParser_weakSelf sym_];
     } while ([self predicts:QUOTESYMBOL_TOKEN_KIND_BACK, QUOTESYMBOL_TOKEN_KIND_DOUBLE, QUOTESYMBOL_TOKEN_KIND_SINGLE, 0]);
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
 
 - (void)sym_ {
-    
-    if ([self predicts:QUOTESYMBOL_TOKEN_KIND_SINGLE, 0]) {
-        [self single_]; 
-    } else if ([self predicts:QUOTESYMBOL_TOKEN_KIND_DOUBLE, 0]) {
-        [self double_]; 
-    } else if ([self predicts:QUOTESYMBOL_TOKEN_KIND_BACK, 0]) {
-        [self back_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:QUOTESYMBOL_TOKEN_KIND_SINGLE, 0]) {
+        [PKParser_weakSelf single_];
+    } else if ([PKParser_weakSelf predicts:QUOTESYMBOL_TOKEN_KIND_DOUBLE, 0]) {
+        [PKParser_weakSelf double_];
+    } else if ([PKParser_weakSelf predicts:QUOTESYMBOL_TOKEN_KIND_BACK, 0]) {
+        [PKParser_weakSelf back_];
     } else {
-        [self raise:@"No viable alternative found in rule 'sym'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'sym'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchSym:)];
 }
 
 - (void)single_ {
-    
-    [self match:QUOTESYMBOL_TOKEN_KIND_SINGLE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:QUOTESYMBOL_TOKEN_KIND_SINGLE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchSingle:)];
 }
 
 - (void)double_ {
-    
-    [self match:QUOTESYMBOL_TOKEN_KIND_DOUBLE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:QUOTESYMBOL_TOKEN_KIND_DOUBLE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDouble:)];
 }
 
 - (void)back_ {
-    
-    [self match:QUOTESYMBOL_TOKEN_KIND_BACK discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:QUOTESYMBOL_TOKEN_KIND_BACK discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchBack:)];
 }

--- a/test/SemanticPredicateParser.m
+++ b/test/SemanticPredicateParser.m
@@ -1,5 +1,6 @@
 #import "SemanticPredicateParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface SemanticPredicateParser ()
@@ -37,17 +38,18 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__start {
-    
+    PKParser_weakSelfDecl;
     do {
-        [self nonReserved_]; 
-    } while ([self speculate:^{ [self nonReserved_]; }]);
+        [PKParser_weakSelf nonReserved_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf nonReserved_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
@@ -57,9 +59,9 @@
 }
 
 - (void)__nonReserved {
-    
+    PKParser_weakSelfDecl;
     [self testAndThrow:(id)^{ return ![@[@"goto", @"const"] containsObject:LS(1)]; }]; 
-    [self matchWord:NO]; 
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNonReserved:)];
 }

--- a/test/TDNSPredicateParser.m
+++ b/test/TDNSPredicateParser.m
@@ -1,5 +1,6 @@
 #import "TDNSPredicateParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface TDNSPredicateParser ()
@@ -341,15 +342,16 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__start {
-    
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf execute:^{
     
 	PKTokenizer *t = self.tokenizer;
 	[t setTokenizerState:t.wordState from:'#' to:'#'];
@@ -369,8 +371,8 @@
  
     }];
     do {
-        [self expr_]; 
-    } while ([self speculate:^{ [self expr_]; }]);
+        [PKParser_weakSelf expr_];
+    } while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf expr_];}]);
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
@@ -380,10 +382,10 @@
 }
 
 - (void)__expr {
-    
-    [self orTerm_]; 
-    while ([self speculate:^{ [self orOrTerm_]; }]) {
-        [self orOrTerm_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf orTerm_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf orOrTerm_];}]) {
+        [PKParser_weakSelf orOrTerm_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchExpr:)];
@@ -394,9 +396,9 @@
 }
 
 - (void)__orOrTerm {
-    
-    [self orKeyword_]; 
-    [self orTerm_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf orKeyword_];
+    [PKParser_weakSelf orTerm_];
 
     [self fireDelegateSelector:@selector(parser:didMatchOrOrTerm:)];
 }
@@ -406,10 +408,10 @@
 }
 
 - (void)__orTerm {
-    
-    [self andTerm_]; 
-    while ([self speculate:^{ [self andAndTerm_]; }]) {
-        [self andAndTerm_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf andTerm_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf andAndTerm_];}]) {
+        [PKParser_weakSelf andAndTerm_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchOrTerm:)];
@@ -420,9 +422,9 @@
 }
 
 - (void)__andAndTerm {
-    
-    [self andKeyword_]; 
-    [self andTerm_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf andKeyword_];
+    [PKParser_weakSelf andTerm_];
 
     [self fireDelegateSelector:@selector(parser:didMatchAndAndTerm:)];
 }
@@ -432,13 +434,13 @@
 }
 
 - (void)__andTerm {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_ALL, TDNSPREDICATE_TOKEN_KIND_ANY, TDNSPREDICATE_TOKEN_KIND_BANG, TDNSPREDICATE_TOKEN_KIND_FALSE, TDNSPREDICATE_TOKEN_KIND_FALSEPREDICATE, TDNSPREDICATE_TOKEN_KIND_NONE, TDNSPREDICATE_TOKEN_KIND_NOT_UPPER, TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY, TDNSPREDICATE_TOKEN_KIND_SOME, TDNSPREDICATE_TOKEN_KIND_TRUE, TDNSPREDICATE_TOKEN_KIND_TRUEPREDICATE, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self primaryExpr_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_OPEN_PAREN, 0]) {
-        [self compoundExpr_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_ALL, TDNSPREDICATE_TOKEN_KIND_ANY, TDNSPREDICATE_TOKEN_KIND_BANG, TDNSPREDICATE_TOKEN_KIND_FALSE, TDNSPREDICATE_TOKEN_KIND_FALSEPREDICATE, TDNSPREDICATE_TOKEN_KIND_NONE, TDNSPREDICATE_TOKEN_KIND_NOT_UPPER, TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY, TDNSPREDICATE_TOKEN_KIND_SOME, TDNSPREDICATE_TOKEN_KIND_TRUE, TDNSPREDICATE_TOKEN_KIND_TRUEPREDICATE, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf primaryExpr_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_OPEN_PAREN, 0]) {
+        [PKParser_weakSelf compoundExpr_];
     } else {
-        [self raise:@"No viable alternative found in rule 'andTerm'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'andTerm'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAndTerm:)];
@@ -449,10 +451,10 @@
 }
 
 - (void)__compoundExpr {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_OPEN_PAREN discard:YES]; 
-    [self expr_]; 
-    [self match:TDNSPREDICATE_TOKEN_KIND_CLOSE_PAREN discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_OPEN_PAREN discard:YES];
+    [PKParser_weakSelf expr_];
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_CLOSE_PAREN discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchCompoundExpr:)];
 }
@@ -462,13 +464,13 @@
 }
 
 - (void)__primaryExpr {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_ALL, TDNSPREDICATE_TOKEN_KIND_ANY, TDNSPREDICATE_TOKEN_KIND_FALSE, TDNSPREDICATE_TOKEN_KIND_FALSEPREDICATE, TDNSPREDICATE_TOKEN_KIND_NONE, TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY, TDNSPREDICATE_TOKEN_KIND_SOME, TDNSPREDICATE_TOKEN_KIND_TRUE, TDNSPREDICATE_TOKEN_KIND_TRUEPREDICATE, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self predicate_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_BANG, TDNSPREDICATE_TOKEN_KIND_NOT_UPPER, 0]) {
-        [self negatedPredicate_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_ALL, TDNSPREDICATE_TOKEN_KIND_ANY, TDNSPREDICATE_TOKEN_KIND_FALSE, TDNSPREDICATE_TOKEN_KIND_FALSEPREDICATE, TDNSPREDICATE_TOKEN_KIND_NONE, TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY, TDNSPREDICATE_TOKEN_KIND_SOME, TDNSPREDICATE_TOKEN_KIND_TRUE, TDNSPREDICATE_TOKEN_KIND_TRUEPREDICATE, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf predicate_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_BANG, TDNSPREDICATE_TOKEN_KIND_NOT_UPPER, 0]) {
+        [PKParser_weakSelf negatedPredicate_];
     } else {
-        [self raise:@"No viable alternative found in rule 'primaryExpr'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'primaryExpr'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchPrimaryExpr:)];
@@ -479,9 +481,9 @@
 }
 
 - (void)__negatedPredicate {
-    
-    [self notKeyword_]; 
-    [self predicate_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf notKeyword_];
+    [PKParser_weakSelf predicate_];
 
     [self fireDelegateSelector:@selector(parser:didMatchNegatedPredicate:)];
 }
@@ -491,17 +493,17 @@
 }
 
 - (void)__predicate {
-    
-    if ([self speculate:^{ [self collectionTestPredicate_]; }]) {
-        [self collectionTestPredicate_]; 
-    } else if ([self speculate:^{ [self boolPredicate_]; }]) {
-        [self boolPredicate_]; 
-    } else if ([self speculate:^{ [self comparisonPredicate_]; }]) {
-        [self comparisonPredicate_]; 
-    } else if ([self speculate:^{ [self stringTestPredicate_]; }]) {
-        [self stringTestPredicate_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf collectionTestPredicate_];}]) {
+        [PKParser_weakSelf collectionTestPredicate_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf boolPredicate_];}]) {
+        [PKParser_weakSelf boolPredicate_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf comparisonPredicate_];}]) {
+        [PKParser_weakSelf comparisonPredicate_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf stringTestPredicate_];}]) {
+        [PKParser_weakSelf stringTestPredicate_];
     } else {
-        [self raise:@"No viable alternative found in rule 'predicate'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'predicate'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchPredicate:)];
@@ -512,19 +514,19 @@
 }
 
 - (void)__value {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self keyPath_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
-        [self string_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
-        [self num_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_FALSE, TDNSPREDICATE_TOKEN_KIND_TRUE, 0]) {
-        [self bool_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY, 0]) {
-        [self array_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf keyPath_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_QUOTEDSTRING, 0]) {
+        [PKParser_weakSelf string_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
+        [PKParser_weakSelf num_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_FALSE, TDNSPREDICATE_TOKEN_KIND_TRUE, 0]) {
+        [PKParser_weakSelf bool_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY, 0]) {
+        [PKParser_weakSelf array_];
     } else {
-        [self raise:@"No viable alternative found in rule 'value'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'value'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchValue:)];
@@ -535,8 +537,8 @@
 }
 
 - (void)__string {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchString:)];
 }
@@ -546,8 +548,8 @@
 }
 
 - (void)__num {
-    
-    [self matchNumber:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchNumber:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNum:)];
 }
@@ -557,13 +559,13 @@
 }
 
 - (void)__bool {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_TRUE, 0]) {
-        [self true_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_FALSE, 0]) {
-        [self false_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_TRUE, 0]) {
+        [PKParser_weakSelf true_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_FALSE, 0]) {
+        [PKParser_weakSelf false_];
     } else {
-        [self raise:@"No viable alternative found in rule 'bool'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'bool'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchBool:)];
@@ -574,8 +576,8 @@
 }
 
 - (void)__true {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_TRUE discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_TRUE discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchTrue:)];
 }
@@ -585,8 +587,8 @@
 }
 
 - (void)__false {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_FALSE discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_FALSE discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchFalse:)];
 }
@@ -596,10 +598,10 @@
 }
 
 - (void)__array {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY discard:NO]; 
-    [self arrayContentsOpt_]; 
-    [self match:TDNSPREDICATE_TOKEN_KIND_CLOSE_CURLY discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY discard:NO];
+    [PKParser_weakSelf arrayContentsOpt_];
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_CLOSE_CURLY discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchArray:)];
 }
@@ -609,9 +611,9 @@
 }
 
 - (void)__arrayContentsOpt {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_FALSE, TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY, TDNSPREDICATE_TOKEN_KIND_TRUE, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self arrayContents_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_FALSE, TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY, TDNSPREDICATE_TOKEN_KIND_TRUE, TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_QUOTEDSTRING, TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf arrayContents_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchArrayContentsOpt:)];
@@ -622,10 +624,10 @@
 }
 
 - (void)__arrayContents {
-    
-    [self value_]; 
-    while ([self speculate:^{ [self commaValue_]; }]) {
-        [self commaValue_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf value_];
+    while ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf commaValue_];}]) {
+        [PKParser_weakSelf commaValue_];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchArrayContents:)];
@@ -636,9 +638,9 @@
 }
 
 - (void)__commaValue {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_COMMA discard:YES]; 
-    [self value_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_COMMA discard:YES];
+    [PKParser_weakSelf value_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCommaValue:)];
 }
@@ -648,8 +650,8 @@
 }
 
 - (void)__keyPath {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchKeyPath:)];
 }
@@ -659,13 +661,13 @@
 }
 
 - (void)__comparisonPredicate {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self numComparisonPredicate_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_ALL, TDNSPREDICATE_TOKEN_KIND_ANY, TDNSPREDICATE_TOKEN_KIND_NONE, TDNSPREDICATE_TOKEN_KIND_SOME, 0]) {
-        [self collectionComparisonPredicate_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf numComparisonPredicate_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_ALL, TDNSPREDICATE_TOKEN_KIND_ANY, TDNSPREDICATE_TOKEN_KIND_NONE, TDNSPREDICATE_TOKEN_KIND_SOME, 0]) {
+        [PKParser_weakSelf collectionComparisonPredicate_];
     } else {
-        [self raise:@"No viable alternative found in rule 'comparisonPredicate'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'comparisonPredicate'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchComparisonPredicate:)];
@@ -676,10 +678,10 @@
 }
 
 - (void)__numComparisonPredicate {
-    
-    [self numComparisonValue_]; 
-    [self comparisonOp_]; 
-    [self numComparisonValue_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf numComparisonValue_];
+    [PKParser_weakSelf comparisonOp_];
+    [PKParser_weakSelf numComparisonValue_];
 
     [self fireDelegateSelector:@selector(parser:didMatchNumComparisonPredicate:)];
 }
@@ -689,13 +691,13 @@
 }
 
 - (void)__numComparisonValue {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self keyPath_]; 
-    } else if ([self predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
-        [self num_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf keyPath_];
+    } else if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_NUMBER, 0]) {
+        [PKParser_weakSelf num_];
     } else {
-        [self raise:@"No viable alternative found in rule 'numComparisonValue'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'numComparisonValue'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchNumComparisonValue:)];
@@ -706,23 +708,23 @@
 }
 
 - (void)__comparisonOp {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_DOUBLE_EQUALS, TDNSPREDICATE_TOKEN_KIND_EQUALS, 0]) {
-        [self eq_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_GT, 0]) {
-        [self gt_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_LT, 0]) {
-        [self lt_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_GE_SYM, TDNSPREDICATE_TOKEN_KIND_HASH_ROCKET, 0]) {
-        [self gtEq_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_EL_SYM, TDNSPREDICATE_TOKEN_KIND_LE_SYM, 0]) {
-        [self ltEq_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_NOT_EQUAL, TDNSPREDICATE_TOKEN_KIND_NOT_EQUALS, 0]) {
-        [self notEq_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_BETWEEN, 0]) {
-        [self between_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_DOUBLE_EQUALS, TDNSPREDICATE_TOKEN_KIND_EQUALS, 0]) {
+        [PKParser_weakSelf eq_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_GT, 0]) {
+        [PKParser_weakSelf gt_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_LT, 0]) {
+        [PKParser_weakSelf lt_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_GE_SYM, TDNSPREDICATE_TOKEN_KIND_HASH_ROCKET, 0]) {
+        [PKParser_weakSelf gtEq_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_EL_SYM, TDNSPREDICATE_TOKEN_KIND_LE_SYM, 0]) {
+        [PKParser_weakSelf ltEq_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_NOT_EQUAL, TDNSPREDICATE_TOKEN_KIND_NOT_EQUALS, 0]) {
+        [PKParser_weakSelf notEq_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_BETWEEN, 0]) {
+        [PKParser_weakSelf between_];
     } else {
-        [self raise:@"No viable alternative found in rule 'comparisonOp'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'comparisonOp'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchComparisonOp:)];
@@ -733,13 +735,13 @@
 }
 
 - (void)__eq {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_EQUALS, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_EQUALS discard:NO]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_DOUBLE_EQUALS, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_DOUBLE_EQUALS discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_EQUALS, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_EQUALS discard:NO];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_DOUBLE_EQUALS, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_DOUBLE_EQUALS discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'eq'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'eq'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchEq:)];
@@ -750,8 +752,8 @@
 }
 
 - (void)__gt {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_GT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_GT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchGt:)];
 }
@@ -761,8 +763,8 @@
 }
 
 - (void)__lt {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_LT discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_LT discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLt:)];
 }
@@ -772,13 +774,13 @@
 }
 
 - (void)__gtEq {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_GE_SYM, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_GE_SYM discard:NO]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_HASH_ROCKET, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_HASH_ROCKET discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_GE_SYM, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_GE_SYM discard:NO];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_HASH_ROCKET, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_HASH_ROCKET discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'gtEq'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'gtEq'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchGtEq:)];
@@ -789,13 +791,13 @@
 }
 
 - (void)__ltEq {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_LE_SYM, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_LE_SYM discard:NO]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_EL_SYM, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_EL_SYM discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_LE_SYM, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_LE_SYM discard:NO];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_EL_SYM, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_EL_SYM discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'ltEq'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'ltEq'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchLtEq:)];
@@ -806,13 +808,13 @@
 }
 
 - (void)__notEq {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_NOT_EQUAL, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_NOT_EQUAL discard:NO]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_NOT_EQUALS, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_NOT_EQUALS discard:NO]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_NOT_EQUAL, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_NOT_EQUAL discard:NO];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_NOT_EQUALS, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_NOT_EQUALS discard:NO];
     } else {
-        [self raise:@"No viable alternative found in rule 'notEq'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'notEq'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchNotEq:)];
@@ -823,8 +825,8 @@
 }
 
 - (void)__between {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_BETWEEN discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_BETWEEN discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchBetween:)];
 }
@@ -834,21 +836,21 @@
 }
 
 - (void)__collectionComparisonPredicate {
-    
-    if ([self speculate:^{ [self collectionLtPredicate_]; }]) {
-        [self collectionLtPredicate_]; 
-    } else if ([self speculate:^{ [self collectionGtPredicate_]; }]) {
-        [self collectionGtPredicate_]; 
-    } else if ([self speculate:^{ [self collectionLtEqPredicate_]; }]) {
-        [self collectionLtEqPredicate_]; 
-    } else if ([self speculate:^{ [self collectionGtEqPredicate_]; }]) {
-        [self collectionGtEqPredicate_]; 
-    } else if ([self speculate:^{ [self collectionEqPredicate_]; }]) {
-        [self collectionEqPredicate_]; 
-    } else if ([self speculate:^{ [self collectionNotEqPredicate_]; }]) {
-        [self collectionNotEqPredicate_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf collectionLtPredicate_];}]) {
+        [PKParser_weakSelf collectionLtPredicate_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf collectionGtPredicate_];}]) {
+        [PKParser_weakSelf collectionGtPredicate_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf collectionLtEqPredicate_];}]) {
+        [PKParser_weakSelf collectionLtEqPredicate_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf collectionGtEqPredicate_];}]) {
+        [PKParser_weakSelf collectionGtEqPredicate_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf collectionEqPredicate_];}]) {
+        [PKParser_weakSelf collectionEqPredicate_];
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf collectionNotEqPredicate_];}]) {
+        [PKParser_weakSelf collectionNotEqPredicate_];
     } else {
-        [self raise:@"No viable alternative found in rule 'collectionComparisonPredicate'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'collectionComparisonPredicate'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchCollectionComparisonPredicate:)];
@@ -859,11 +861,11 @@
 }
 
 - (void)__collectionLtPredicate {
-    
-    [self aggregateOp_]; 
-    [self collection_]; 
-    [self lt_]; 
-    [self value_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf aggregateOp_];
+    [PKParser_weakSelf collection_];
+    [PKParser_weakSelf lt_];
+    [PKParser_weakSelf value_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCollectionLtPredicate:)];
 }
@@ -873,11 +875,11 @@
 }
 
 - (void)__collectionGtPredicate {
-    
-    [self aggregateOp_]; 
-    [self collection_]; 
-    [self gt_]; 
-    [self value_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf aggregateOp_];
+    [PKParser_weakSelf collection_];
+    [PKParser_weakSelf gt_];
+    [PKParser_weakSelf value_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCollectionGtPredicate:)];
 }
@@ -887,11 +889,11 @@
 }
 
 - (void)__collectionLtEqPredicate {
-    
-    [self aggregateOp_]; 
-    [self collection_]; 
-    [self ltEq_]; 
-    [self value_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf aggregateOp_];
+    [PKParser_weakSelf collection_];
+    [PKParser_weakSelf ltEq_];
+    [PKParser_weakSelf value_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCollectionLtEqPredicate:)];
 }
@@ -901,11 +903,11 @@
 }
 
 - (void)__collectionGtEqPredicate {
-    
-    [self aggregateOp_]; 
-    [self collection_]; 
-    [self gtEq_]; 
-    [self value_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf aggregateOp_];
+    [PKParser_weakSelf collection_];
+    [PKParser_weakSelf gtEq_];
+    [PKParser_weakSelf value_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCollectionGtEqPredicate:)];
 }
@@ -915,11 +917,11 @@
 }
 
 - (void)__collectionEqPredicate {
-    
-    [self aggregateOp_]; 
-    [self collection_]; 
-    [self eq_]; 
-    [self value_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf aggregateOp_];
+    [PKParser_weakSelf collection_];
+    [PKParser_weakSelf eq_];
+    [PKParser_weakSelf value_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCollectionEqPredicate:)];
 }
@@ -929,11 +931,11 @@
 }
 
 - (void)__collectionNotEqPredicate {
-    
-    [self aggregateOp_]; 
-    [self collection_]; 
-    [self notEq_]; 
-    [self value_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf aggregateOp_];
+    [PKParser_weakSelf collection_];
+    [PKParser_weakSelf notEq_];
+    [PKParser_weakSelf value_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCollectionNotEqPredicate:)];
 }
@@ -943,13 +945,13 @@
 }
 
 - (void)__boolPredicate {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_TRUEPREDICATE, 0]) {
-        [self truePredicate_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_FALSEPREDICATE, 0]) {
-        [self falsePredicate_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_TRUEPREDICATE, 0]) {
+        [PKParser_weakSelf truePredicate_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_FALSEPREDICATE, 0]) {
+        [PKParser_weakSelf falsePredicate_];
     } else {
-        [self raise:@"No viable alternative found in rule 'boolPredicate'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'boolPredicate'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchBoolPredicate:)];
@@ -960,8 +962,8 @@
 }
 
 - (void)__truePredicate {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_TRUEPREDICATE discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_TRUEPREDICATE discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchTruePredicate:)];
 }
@@ -971,8 +973,8 @@
 }
 
 - (void)__falsePredicate {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_FALSEPREDICATE discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_FALSEPREDICATE discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchFalsePredicate:)];
 }
@@ -982,13 +984,13 @@
 }
 
 - (void)__andKeyword {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_AND_UPPER, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_AND_UPPER discard:YES]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_DOUBLE_AMPERSAND, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_DOUBLE_AMPERSAND discard:YES]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_AND_UPPER, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_AND_UPPER discard:YES];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_DOUBLE_AMPERSAND, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_DOUBLE_AMPERSAND discard:YES];
     } else {
-        [self raise:@"No viable alternative found in rule 'andKeyword'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'andKeyword'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAndKeyword:)];
@@ -999,13 +1001,13 @@
 }
 
 - (void)__orKeyword {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_OR_UPPER, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_OR_UPPER discard:YES]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_DOUBLE_PIPE, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_DOUBLE_PIPE discard:YES]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_OR_UPPER, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_OR_UPPER discard:YES];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_DOUBLE_PIPE, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_DOUBLE_PIPE discard:YES];
     } else {
-        [self raise:@"No viable alternative found in rule 'orKeyword'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'orKeyword'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchOrKeyword:)];
@@ -1016,13 +1018,13 @@
 }
 
 - (void)__notKeyword {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_NOT_UPPER, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_NOT_UPPER discard:YES]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_BANG, 0]) {
-        [self match:TDNSPREDICATE_TOKEN_KIND_BANG discard:YES]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_NOT_UPPER, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_NOT_UPPER discard:YES];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_BANG, 0]) {
+        [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_BANG discard:YES];
     } else {
-        [self raise:@"No viable alternative found in rule 'notKeyword'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'notKeyword'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchNotKeyword:)];
@@ -1033,10 +1035,10 @@
 }
 
 - (void)__stringTestPredicate {
-    
-    [self string_]; 
-    [self stringTestOp_]; 
-    [self value_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf string_];
+    [PKParser_weakSelf stringTestOp_];
+    [PKParser_weakSelf value_];
 
     [self fireDelegateSelector:@selector(parser:didMatchStringTestPredicate:)];
 }
@@ -1046,19 +1048,19 @@
 }
 
 - (void)__stringTestOp {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_BEGINSWITH, 0]) {
-        [self beginswith_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_CONTAINS, 0]) {
-        [self contains_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_ENDSWITH, 0]) {
-        [self endswith_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_LIKE, 0]) {
-        [self like_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_MATCHES, 0]) {
-        [self matches_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_BEGINSWITH, 0]) {
+        [PKParser_weakSelf beginswith_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_CONTAINS, 0]) {
+        [PKParser_weakSelf contains_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_ENDSWITH, 0]) {
+        [PKParser_weakSelf endswith_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_LIKE, 0]) {
+        [PKParser_weakSelf like_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_MATCHES, 0]) {
+        [PKParser_weakSelf matches_];
     } else {
-        [self raise:@"No viable alternative found in rule 'stringTestOp'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'stringTestOp'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchStringTestOp:)];
@@ -1069,8 +1071,8 @@
 }
 
 - (void)__beginswith {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_BEGINSWITH discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_BEGINSWITH discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchBeginswith:)];
 }
@@ -1080,8 +1082,8 @@
 }
 
 - (void)__contains {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_CONTAINS discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_CONTAINS discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchContains:)];
 }
@@ -1091,8 +1093,8 @@
 }
 
 - (void)__endswith {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_ENDSWITH discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_ENDSWITH discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchEndswith:)];
 }
@@ -1102,8 +1104,8 @@
 }
 
 - (void)__like {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_LIKE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_LIKE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchLike:)];
 }
@@ -1113,8 +1115,8 @@
 }
 
 - (void)__matches {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_MATCHES discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_MATCHES discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchMatches:)];
 }
@@ -1124,10 +1126,10 @@
 }
 
 - (void)__collectionTestPredicate {
-    
-    [self value_]; 
-    [self inKeyword_]; 
-    [self collection_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf value_];
+    [PKParser_weakSelf inKeyword_];
+    [PKParser_weakSelf collection_];
 
     [self fireDelegateSelector:@selector(parser:didMatchCollectionTestPredicate:)];
 }
@@ -1137,13 +1139,13 @@
 }
 
 - (void)__collection {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self keyPath_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY, 0]) {
-        [self array_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf keyPath_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_OPEN_CURLY, 0]) {
+        [PKParser_weakSelf array_];
     } else {
-        [self raise:@"No viable alternative found in rule 'collection'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'collection'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchCollection:)];
@@ -1154,8 +1156,8 @@
 }
 
 - (void)__inKeyword {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_INKEYWORD discard:YES]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_INKEYWORD discard:YES];
 
     [self fireDelegateSelector:@selector(parser:didMatchInKeyword:)];
 }
@@ -1165,17 +1167,17 @@
 }
 
 - (void)__aggregateOp {
-    
-    if ([self predicts:TDNSPREDICATE_TOKEN_KIND_ANY, 0]) {
-        [self any_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_SOME, 0]) {
-        [self some_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_ALL, 0]) {
-        [self all_]; 
-    } else if ([self predicts:TDNSPREDICATE_TOKEN_KIND_NONE, 0]) {
-        [self none_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_ANY, 0]) {
+        [PKParser_weakSelf any_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_SOME, 0]) {
+        [PKParser_weakSelf some_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_ALL, 0]) {
+        [PKParser_weakSelf all_];
+    } else if ([PKParser_weakSelf predicts:TDNSPREDICATE_TOKEN_KIND_NONE, 0]) {
+        [PKParser_weakSelf none_];
     } else {
-        [self raise:@"No viable alternative found in rule 'aggregateOp'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'aggregateOp'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchAggregateOp:)];
@@ -1186,8 +1188,8 @@
 }
 
 - (void)__any {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_ANY discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_ANY discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchAny:)];
 }
@@ -1197,8 +1199,8 @@
 }
 
 - (void)__some {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_SOME discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_SOME discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchSome:)];
 }
@@ -1208,8 +1210,8 @@
 }
 
 - (void)__all {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_ALL discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_ALL discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchAll:)];
 }
@@ -1219,8 +1221,8 @@
 }
 
 - (void)__none {
-    
-    [self match:TDNSPREDICATE_TOKEN_KIND_NONE discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:TDNSPREDICATE_TOKEN_KIND_NONE discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchNone:)];
 }

--- a/test/TableIndexParser.m
+++ b/test/TableIndexParser.m
@@ -1,5 +1,6 @@
 #import "TableIndexParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface TableIndexParser ()
@@ -34,17 +35,18 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self qualifiedTableName_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf qualifiedTableName_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)qualifiedTableName_ {
-    
-    [self name_]; 
-    [self indexOpt_]; 
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf name_];
+    [PKParser_weakSelf indexOpt_];
+    [PKParser_weakSelf execute:^{
     
     // now stack contains 3 `NSString`s. 
     // ["mydb", "mytable", "foo"]
@@ -59,34 +61,34 @@
 }
 
 - (void)databaseName_ {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDatabaseName:)];
 }
 
 - (void)tableName_ {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTableName:)];
 }
 
 - (void)indexName_ {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchIndexName:)];
 }
 
 - (void)name_ {
-    
-    if ([self speculate:^{ [self databaseName_]; [self match:TABLEINDEX_TOKEN_KIND_DOT discard:YES]; }]) {
-        [self databaseName_]; 
-        [self match:TABLEINDEX_TOKEN_KIND_DOT discard:YES]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf databaseName_];[PKParser_weakSelf match:TABLEINDEX_TOKEN_KIND_DOT discard:YES];}]) {
+        [PKParser_weakSelf databaseName_];
+        [PKParser_weakSelf match:TABLEINDEX_TOKEN_KIND_DOT discard:YES];
     }
-    [self tableName_]; 
-    [self execute:^{
+    [PKParser_weakSelf tableName_];
+    [PKParser_weakSelf execute:^{
     
     // now stack contains 2 `PKToken`s of type Word
     // [<Word «mydb»>, <Word «mytable»>]
@@ -102,12 +104,12 @@
 }
 
 - (void)indexOpt_ {
-    
-    if ([self predicts:TABLEINDEX_TOKEN_KIND_INDEXED, TABLEINDEX_TOKEN_KIND_NOT_UPPER, 0]) {
-        [self index_]; 
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TABLEINDEX_TOKEN_KIND_INDEXED, TABLEINDEX_TOKEN_KIND_NOT_UPPER, 0]) {
+        [PKParser_weakSelf index_];
     } else {
-        [self matchEmpty:NO]; 
-        [self execute:^{
+        [PKParser_weakSelf matchEmpty:NO];
+        [PKParser_weakSelf execute:^{
          PUSH(@""); 
         }];
     }
@@ -116,12 +118,12 @@
 }
 
 - (void)index_ {
-    
-    if ([self predicts:TABLEINDEX_TOKEN_KIND_INDEXED, 0]) {
-        [self match:TABLEINDEX_TOKEN_KIND_INDEXED discard:YES]; 
-        [self match:TABLEINDEX_TOKEN_KIND_BY discard:YES]; 
-        [self indexName_]; 
-        [self execute:^{
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TABLEINDEX_TOKEN_KIND_INDEXED, 0]) {
+        [PKParser_weakSelf match:TABLEINDEX_TOKEN_KIND_INDEXED discard:YES];
+        [PKParser_weakSelf match:TABLEINDEX_TOKEN_KIND_BY discard:YES];
+        [PKParser_weakSelf indexName_];
+        [PKParser_weakSelf execute:^{
          
         // now top of stack will be a Quoted String `PKToken`
         // […, <Quoted String «"foo"»>]
@@ -133,14 +135,14 @@
         PUSH(indexName);
     
         }];
-    } else if ([self predicts:TABLEINDEX_TOKEN_KIND_NOT_UPPER, 0]) {
-        [self match:TABLEINDEX_TOKEN_KIND_NOT_UPPER discard:YES]; 
-        [self match:TABLEINDEX_TOKEN_KIND_INDEXED discard:YES]; 
-        [self execute:^{
+    } else if ([PKParser_weakSelf predicts:TABLEINDEX_TOKEN_KIND_NOT_UPPER, 0]) {
+        [PKParser_weakSelf match:TABLEINDEX_TOKEN_KIND_NOT_UPPER discard:YES];
+        [PKParser_weakSelf match:TABLEINDEX_TOKEN_KIND_INDEXED discard:YES];
+        [PKParser_weakSelf execute:^{
          PUSH(@""); 
         }];
     } else {
-        [self raise:@"No viable alternative found in rule 'index'."];
+        [PKParser_weakSelf raise:@"No viable alternative found in rule 'index'."];
     }
 
     [self fireDelegateSelector:@selector(parser:didMatchIndex:)];

--- a/test/TableIndexSpecParser.m
+++ b/test/TableIndexSpecParser.m
@@ -1,5 +1,6 @@
 #import "TableIndexSpecParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface TableIndexSpecParser ()
@@ -34,17 +35,18 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self qualifiedTableName_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf qualifiedTableName_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)qualifiedTableName_ {
-    
-    [self name_]; 
-    [self indexOpt_]; 
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf name_];
+    [PKParser_weakSelf indexOpt_];
+    [PKParser_weakSelf execute:^{
     
     // NSString *indexName = POP();
     // NSString *tableName = POP();
@@ -57,31 +59,31 @@
 }
 
 - (void)databaseName_ {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchDatabaseName:)];
 }
 
 - (void)tableName_ {
-    
-    [self matchWord:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchWord:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchTableName:)];
 }
 
 - (void)indexName_ {
-    
-    [self matchQuotedString:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf matchQuotedString:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchIndexName:)];
 }
 
 - (void)name_ {
-    
-    [self prefixOpt_]; 
-    [self tableName_]; 
-    [self execute:^{
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf prefixOpt_];
+    [PKParser_weakSelf tableName_];
+    [PKParser_weakSelf execute:^{
     
     NSString *tableName = POP_STR();
     NSString *dbName = POP_STR();
@@ -94,16 +96,16 @@
 }
 
 - (void)prefixOpt_ {
-    
-    if ([self predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
-        [self databaseName_]; 
-        [self match:TABLEINDEXSPEC_TOKEN_KIND_DOT discard:YES]; 
-        [self execute:^{
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf predicts:TOKEN_KIND_BUILTIN_WORD, 0]) {
+        [PKParser_weakSelf databaseName_];
+        [PKParser_weakSelf match:TABLEINDEXSPEC_TOKEN_KIND_DOT discard:YES];
+        [PKParser_weakSelf execute:^{
          PUSH(POP_STR()); 
         }];
     } else {
-        [self matchEmpty:NO]; 
-        [self execute:^{
+        [PKParser_weakSelf matchEmpty:NO];
+        [PKParser_weakSelf execute:^{
          PUSH(@""); 
         }];
     }
@@ -112,27 +114,27 @@
 }
 
 - (void)indexOpt_ {
-    
-    if ([self speculate:^{ [self match:TABLEINDEXSPEC_TOKEN_KIND_INDEXED discard:YES]; [self match:TABLEINDEXSPEC_TOKEN_KIND_BY discard:YES]; [self indexName_]; }]) {
-        [self match:TABLEINDEXSPEC_TOKEN_KIND_INDEXED discard:YES]; 
-        [self match:TABLEINDEXSPEC_TOKEN_KIND_BY discard:YES]; 
-        [self indexName_]; 
-        [self execute:^{
+    PKParser_weakSelfDecl;
+    if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:TABLEINDEXSPEC_TOKEN_KIND_INDEXED discard:YES];[PKParser_weakSelf match:TABLEINDEXSPEC_TOKEN_KIND_BY discard:YES];[PKParser_weakSelf indexName_];}]) {
+        [PKParser_weakSelf match:TABLEINDEXSPEC_TOKEN_KIND_INDEXED discard:YES];
+        [PKParser_weakSelf match:TABLEINDEXSPEC_TOKEN_KIND_BY discard:YES];
+        [PKParser_weakSelf indexName_];
+        [PKParser_weakSelf execute:^{
          
         NSString *indexName = POP_STR();
         indexName = [indexName substringWithRange:NSMakeRange(1, [indexName length]-2)];
         PUSH(indexName);
     
         }];
-    } else if ([self speculate:^{ [self match:TABLEINDEXSPEC_TOKEN_KIND_INDEXED discard:YES]; [self match:TABLEINDEXSPEC_TOKEN_KIND_NOT_UPPER discard:YES]; }]) {
-        [self match:TABLEINDEXSPEC_TOKEN_KIND_INDEXED discard:YES]; 
-        [self match:TABLEINDEXSPEC_TOKEN_KIND_NOT_UPPER discard:YES]; 
-        [self execute:^{
+    } else if ([PKParser_weakSelf speculate:^{ [PKParser_weakSelf match:TABLEINDEXSPEC_TOKEN_KIND_INDEXED discard:YES];[PKParser_weakSelf match:TABLEINDEXSPEC_TOKEN_KIND_NOT_UPPER discard:YES];}]) {
+        [PKParser_weakSelf match:TABLEINDEXSPEC_TOKEN_KIND_INDEXED discard:YES];
+        [PKParser_weakSelf match:TABLEINDEXSPEC_TOKEN_KIND_NOT_UPPER discard:YES];
+        [PKParser_weakSelf execute:^{
          PUSH(@""); 
         }];
     } else {
-        [self matchEmpty:NO]; 
-        [self execute:^{
+        [PKParser_weakSelf matchEmpty:NO];
+        [PKParser_weakSelf execute:^{
          PUSH(@""); 
         }];
     }

--- a/test/UnfinishedSeqParser.m
+++ b/test/UnfinishedSeqParser.m
@@ -1,5 +1,6 @@
 #import "UnfinishedSeqParser.h"
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKParser+Subclass.h>
 
 
 @interface UnfinishedSeqParser ()
@@ -45,17 +46,18 @@
 }
 
 - (void)start {
+    PKParser_weakSelfDecl;
 
-    [self start_]; 
-    [self matchEOF:YES]; 
+    [PKParser_weakSelf start_];
+    [PKParser_weakSelf matchEOF:YES];
 
 }
 
 - (void)__start {
-    
-    [self a_]; 
-    [self b_]; 
-    [self a_]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf a_];
+    [PKParser_weakSelf b_];
+    [PKParser_weakSelf a_];
 
     [self fireDelegateSelector:@selector(parser:didMatchStart:)];
 }
@@ -65,8 +67,8 @@
 }
 
 - (void)__a {
-    
-    [self match:UNFINISHEDSEQ_TOKEN_KIND_A discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:UNFINISHEDSEQ_TOKEN_KIND_A discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchA:)];
 }
@@ -76,8 +78,8 @@
 }
 
 - (void)__b {
-    
-    [self match:UNFINISHEDSEQ_TOKEN_KIND_B discard:NO]; 
+    PKParser_weakSelfDecl;
+    [PKParser_weakSelf match:UNFINISHEDSEQ_TOKEN_KIND_B discard:NO];
 
     [self fireDelegateSelector:@selector(parser:didMatchB:)];
 }


### PR DESCRIPTION
To do this, all the references to self inside blocks need to be
weak, otherwise nothing gets freed.

This has been implemented with a couple of macros that take different
values depending on whether the code is compiled with ARC.
All references to self that would appear inside a block (i.e.
just about any of the templated fragments) need to use PKParser_weakSelf
instead of self, and each of the method templates needs to include
PKParser_weakSelfDecl.

Note that the subclass needs to be compiled with -fobjc-arc-exceptions
to avoid leaks, because PKParser uses exceptions for control flow heavily.