### PR TITLE
Generic delegate callbacks

### DIFF
--- a/include/PEGKit/PKParser.h
+++ b/include/PEGKit/PKParser.h
@@ -56,9 +56,42 @@ enum {
     TOKEN_KIND_BUILTIN_ANY = 13,
 };
 
+
+@class PKParser;
+@protocol PKParserDelegate <NSObject>
+
+@optional
+
+/**
+ * Called just before a grammar rule will be matched.
+ *
+ * @param rule The name of the rule that will be matched (in sentence case, to match the willMatchFoo callback).
+ */
+-(void)parser:(PKParser *)parser willMatch:(NSString *)rule;
+
+/**
+ * Called after a grammar rule has been matched.
+ *
+ * @param rule The name of the rule that has been matched (in sentence case, to match the didMatchFoo callback).
+ */
+-(void)parser:(PKParser *)parser didMatch:(NSString *)rule;
+
+@end
+
+
 @interface PKParser : NSObject <PKTokenizerDelegate>
 
-- (instancetype)initWithDelegate:(id)d; // designated initializer
+/**
+ * Designated initializer.
+ *
+ * @param d This will receive calls to -parser:willMatchFoo: and parser:didMatchFoo:
+ * where Foo is the name of the grammar rule that is being matched.  These calls
+ * will receive self and self.assembly as parameters.  This delegate may optionally
+ * also implement PKParserDelegate and receive calls to -parser:willMatch: and
+ * -parser:didMatch:.  All these calls are optional and so the delegate need not
+ * implement all of them.
+ */
+- (instancetype)initWithDelegate:(id)d;
 
 - (id)parseString:(NSString *)input error:(NSError **)outErr;
 - (id)parseStream:(NSInputStream *)input error:(NSError **)outErr;

--- a/include/PEGKit/PKParser.h
+++ b/include/PEGKit/PKParser.h
@@ -76,6 +76,11 @@ enum {
  */
 -(void)parser:(PKParser *)parser didMatch:(NSString *)rule;
 
+/**
+ * Called when the parse fails to match anything.
+ */
+-(void)parser:(PKParser *)parser didFailToMatch:(PKAssembly *)assembly;
+
 @end
 
 

--- a/src/PKParser.m
+++ b/src/PKParser.m
@@ -40,10 +40,6 @@ NSInteger PEGKitRecognitionErrorCode = 1;
 NSString * const PEGKitRecognitionTokenMatchFailed = @"Failed to match next input token";
 NSString * const PEGKitRecognitionPredicateFailed = @"Predicate failed";
 
-@interface NSObject ()
-- (void)parser:(PKParser *)p didFailToMatch:(PKAssembly *)a;
-@end
-
 @interface PKAssembly ()
 - (void)consume:(PKToken *)tok;
 @property (nonatomic, readwrite, retain) NSMutableArray *stack;

--- a/src/PKParser.m
+++ b/src/PKParser.m
@@ -399,10 +399,25 @@ NSString * const PEGKitRecognitionPredicateFailed = @"Predicate failed";
 
 
 - (void)fireDelegateSelector:(SEL)sel {
-    if (self.isSpeculating) return;
-    
-    if (_delegate && [_delegate respondsToSelector:sel]) {
+    if (self.isSpeculating || _delegate == nil) return;
+
+    [self fireDelegateMatchRule:sel delegateSelector:@selector(parser:willMatch:)];
+    [self fireDelegateMatchRule:sel delegateSelector:@selector(parser:didMatch:)];
+
+    if ([_delegate respondsToSelector:sel]) {
         [_delegate performSelector:sel withObject:self withObject:_assembly];
+    }
+}
+
+
+- (void)fireDelegateMatchRule:(SEL)sel delegateSelector:(SEL)delegateSelector {
+    NSString * selStr = NSStringFromSelector(sel);
+    NSString * prefix = NSStringFromSelector(delegateSelector);
+    prefix = [prefix substringToIndex:prefix.length - 1];
+
+    if ([selStr hasPrefix:prefix] && [_delegate respondsToSelector:delegateSelector]) {
+        NSString * rule = [selStr substringWithRange:NSMakeRange(prefix.length, selStr.length - prefix.length - 1)];
+        [_delegate performSelector:delegateSelector withObject:self withObject:rule];
     }
 }
 


### PR DESCRIPTION
Add a new feature to call `parser:willMatch:` or `parser:didMatch:`
on the delegate whenever a rule is matched.

This adds a new `PKParserDelegate` protocol, so that the selectors are
declared (though `PKParser.init` does not require this protocol to be
implemented by its parameter, because this whole protocol is optional).

Move the `parser:didFailToMatch:` declaration to `PKParserDelegate`,
now that we have such a thing.
