### PR TITLE
Fix call to NSWorkspace.selectFile:inFileViewerRootedAtPath:

### DIFF
--- a/ParserGenApp/PGDocument.m
+++ b/ParserGenApp/PGDocument.m
@@ -214,7 +214,7 @@
     path = [path stringByAppendingPathComponent:filename];
     
     if ([path length]) {
-        [[NSWorkspace sharedWorkspace] selectFile:path inFileViewerRootedAtPath:nil];
+        [[NSWorkspace sharedWorkspace] selectFile:path inFileViewerRootedAtPath:@""];
     }
 }
 


### PR DESCRIPTION
The path parameter is declared as being non-null (in the Xcode 7 10.11 SDK)
so pass the empty string rather than nil.