### PR TITLE
Move internal declarations to +Subclass header files

### DIFF
--- a/PEGKit.xcodeproj/project.pbxproj
+++ b/PEGKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3D0466A918E1D9770022A1BC /* OCMock.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D37214CA18DF3B0100525058 /* OCMock.framework */; };
+		4032A4C01C3115D0005442DD /* PKToken+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 4032A4BF1C3115D0005442DD /* PKToken+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D306298218E1ED5D00EF745E /* TDTestScaffold.m in Sources */ = {isa = PBXBuildFile; fileRef = D306298118E1ED5D00EF745E /* TDTestScaffold.m */; };
 		D3083AB61705F05C00DA6F95 /* elementsAssign.grammar in Resources */ = {isa = PBXBuildFile; fileRef = D3083AB51705F05C00DA6F95 /* elementsAssign.grammar */; };
 		D3083AB91705F09B00DA6F95 /* ElementAssignParserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D3083AB81705F09B00DA6F95 /* ElementAssignParserTest.m */; };
@@ -478,6 +479,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4032A4BF1C3115D0005442DD /* PKToken+Subclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "PKToken+Subclass.h"; path = "include/PEGKit/PKToken+Subclass.h"; sourceTree = "<group>"; };
 		D302272A17020F9400594F16 /* PGClassImplementationTemplate.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = PGClassImplementationTemplate.txt; path = res/PGClassImplementationTemplate.txt; sourceTree = "<group>"; };
 		D306298118E1ED5D00EF745E /* TDTestScaffold.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TDTestScaffold.m; path = test/TDTestScaffold.m; sourceTree = "<group>"; };
 		D3083AB51705F05C00DA6F95 /* elementsAssign.grammar */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = elementsAssign.grammar; path = res/elementsAssign.grammar; sourceTree = "<group>"; };
@@ -1161,6 +1163,7 @@
 			children = (
 				D3C221C30FFE8C07004514FE /* PKToken.h */,
 				D34BAE950FF9D20900D7773A /* PKToken.m */,
+				4032A4BF1C3115D0005442DD /* PKToken+Subclass.h */,
 				D3C221C90FFE8C15004514FE /* PKTokenizer.h */,
 				D34BAE990FF9D20900D7773A /* PKTokenizer.m */,
 				D3C221CC0FFE8C1B004514FE /* PKTokenizerState.h */,
@@ -1539,6 +1542,7 @@
 				D317C0E418D1F4050036BE75 /* PKMultiLineCommentState.h in Headers */,
 				D317C0E718D1F4050036BE75 /* PKTwitterState.h in Headers */,
 				D317C0DF18D1F4050036BE75 /* PKWordState.h in Headers */,
+				4032A4C01C3115D0005442DD /* PKToken+Subclass.h in Headers */,
 				D317C0D618D1F4050036BE75 /* PKAssembly.h in Headers */,
 				D317C0E518D1F4050036BE75 /* PKEmailState.h in Headers */,
 				D317C0E818D1F4050036BE75 /* PKHashtagState.h in Headers */,

--- a/PEGKit.xcodeproj/project.pbxproj
+++ b/PEGKit.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3D0466A918E1D9770022A1BC /* OCMock.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D37214CA18DF3B0100525058 /* OCMock.framework */; };
 		4032A4C01C3115D0005442DD /* PKToken+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 4032A4BF1C3115D0005442DD /* PKToken+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4032A4C21C312D78005442DD /* PKTokenizerState+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 4032A4C11C312D78005442DD /* PKTokenizerState+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D306298218E1ED5D00EF745E /* TDTestScaffold.m in Sources */ = {isa = PBXBuildFile; fileRef = D306298118E1ED5D00EF745E /* TDTestScaffold.m */; };
 		D3083AB61705F05C00DA6F95 /* elementsAssign.grammar in Resources */ = {isa = PBXBuildFile; fileRef = D3083AB51705F05C00DA6F95 /* elementsAssign.grammar */; };
 		D3083AB91705F09B00DA6F95 /* ElementAssignParserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D3083AB81705F09B00DA6F95 /* ElementAssignParserTest.m */; };
@@ -480,6 +481,7 @@
 
 /* Begin PBXFileReference section */
 		4032A4BF1C3115D0005442DD /* PKToken+Subclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "PKToken+Subclass.h"; path = "include/PEGKit/PKToken+Subclass.h"; sourceTree = "<group>"; };
+		4032A4C11C312D78005442DD /* PKTokenizerState+Subclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "PKTokenizerState+Subclass.h"; path = "include/PEGKit/PKTokenizerState+Subclass.h"; sourceTree = "<group>"; };
 		D302272A17020F9400594F16 /* PGClassImplementationTemplate.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = PGClassImplementationTemplate.txt; path = res/PGClassImplementationTemplate.txt; sourceTree = "<group>"; };
 		D306298118E1ED5D00EF745E /* TDTestScaffold.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TDTestScaffold.m; path = test/TDTestScaffold.m; sourceTree = "<group>"; };
 		D3083AB51705F05C00DA6F95 /* elementsAssign.grammar */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = elementsAssign.grammar; path = res/elementsAssign.grammar; sourceTree = "<group>"; };
@@ -1168,6 +1170,7 @@
 				D34BAE990FF9D20900D7773A /* PKTokenizer.m */,
 				D3C221CC0FFE8C1B004514FE /* PKTokenizerState.h */,
 				D34BAE9B0FF9D20900D7773A /* PKTokenizerState.m */,
+				4032A4C11C312D78005442DD /* PKTokenizerState+Subclass.h */,
 			);
 			name = tokenizer;
 			sourceTree = SOURCE_ROOT;
@@ -1541,6 +1544,7 @@
 				D3A29E4118E8516F00DC591E /* PKParser+Subclass.h in Headers */,
 				D317C0E418D1F4050036BE75 /* PKMultiLineCommentState.h in Headers */,
 				D317C0E718D1F4050036BE75 /* PKTwitterState.h in Headers */,
+				4032A4C21C312D78005442DD /* PKTokenizerState+Subclass.h in Headers */,
 				D317C0DF18D1F4050036BE75 /* PKWordState.h in Headers */,
 				4032A4C01C3115D0005442DD /* PKToken+Subclass.h in Headers */,
 				D317C0D618D1F4050036BE75 /* PKAssembly.h in Headers */,

--- a/include/PEGKit/PKToken+Subclass.h
+++ b/include/PEGKit/PKToken+Subclass.h
@@ -1,0 +1,29 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2014 Todd Ditchendorf
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <PEGKit/PKToken.h>
+
+@interface PKToken ()
+
+@property (nonatomic, readwrite) NSUInteger offset;
+
+@end

--- a/include/PEGKit/PKTokenizerState+Subclass.h
+++ b/include/PEGKit/PKTokenizerState+Subclass.h
@@ -1,0 +1,36 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2014 Todd Ditchendorf
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@interface PKTokenizerState ()
+
+- (void)resetWithReader:(PKReader *)r;
+
+- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
+
+- (void)append:(PKUniChar)c;
+- (void)appendString:(NSString *)s;
+
+- (NSString *)bufferedString;
+
+@property (nonatomic) NSUInteger offset;
+
+@end

--- a/src/PKCommentState.m
+++ b/src/PKCommentState.m
@@ -22,15 +22,11 @@
 
 #import <PEGKit/PKCommentState.h>
 #import <PEGKit/PKTokenizer.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKSingleLineCommentState.h>
 #import <PEGKit/PKMultiLineCommentState.h>
 #import "PKSymbolRootNode.h"
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizerState ()
 - (void)resetWithReader:(PKReader *)r;

--- a/src/PKCommentState.m
+++ b/src/PKCommentState.m
@@ -22,17 +22,12 @@
 
 #import <PEGKit/PKCommentState.h>
 #import <PEGKit/PKTokenizer.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKSingleLineCommentState.h>
 #import <PEGKit/PKMultiLineCommentState.h>
 #import "PKSymbolRootNode.h"
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
-@property (nonatomic) NSUInteger offset;
-@end
 
 @interface PKCommentState ()
 @property (nonatomic, retain) PKSymbolRootNode *rootNode;

--- a/src/PKDelimitState.m
+++ b/src/PKDelimitState.m
@@ -23,6 +23,7 @@
 #import <PEGKit/PKDelimitState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKWhitespaceState.h>
 #import <PEGKit/PKTypes.h>
@@ -33,16 +34,6 @@
 
 @interface PKTokenizer ()
 - (NSInteger)tokenKindForStringValue:(NSString *)str;
-@end
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (void)append:(PKUniChar)c;
-- (void)appendString:(NSString *)s;
-- (NSString *)bufferedString;
-- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
-- (void)addStartMarker:(NSString *)start endMarker:(NSString *)end allowedCharacterSet:(NSCharacterSet *)set tokenKind:(NSInteger)kind;
-@property (nonatomic) NSUInteger offset;
 @end
 
 @interface PKDelimitState ()

--- a/src/PKDelimitState.m
+++ b/src/PKDelimitState.m
@@ -23,17 +23,13 @@
 #import <PEGKit/PKDelimitState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKWhitespaceState.h>
 #import <PEGKit/PKTypes.h>
 #import "PKSymbolRootNode.h"
 
 #import "PKDelimitDescriptorCollection.h"
 #import "PKDelimitDescriptor.h"
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizer ()
 - (NSInteger)tokenKindForStringValue:(NSString *)str;

--- a/src/PKEmailState.m
+++ b/src/PKEmailState.m
@@ -23,16 +23,9 @@
 #import <PEGKit/PKEmailState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (void)append:(PKUniChar)c;
-- (NSString *)bufferedString;
-- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
-@property (nonatomic) NSUInteger offset;
-@end
 
 @interface PKEmailState ()
 - (BOOL)parseNameFromReader:(PKReader *)r;

--- a/src/PKEmailState.m
+++ b/src/PKEmailState.m
@@ -23,12 +23,8 @@
 #import <PEGKit/PKEmailState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizerState ()
 - (void)resetWithReader:(PKReader *)r;

--- a/src/PKHashtagState.m
+++ b/src/PKHashtagState.m
@@ -24,11 +24,7 @@
 #import <PEGKit/PKHashtagState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
-#import <PEGKit/PKToken.h>
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
+#import <PEGKit/PKToken+Subclass.h>
 
 @interface PKTokenizerState ()
 - (void)resetWithReader:(PKReader *)r;

--- a/src/PKHashtagState.m
+++ b/src/PKHashtagState.m
@@ -24,19 +24,8 @@
 #import <PEGKit/PKHashtagState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKToken+Subclass.h>
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (void)append:(PKUniChar)c;
-- (NSString *)bufferedString;
-- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
-@property (nonatomic) NSUInteger offset;
-@end
-
-@interface PKHashtagState ()
-
-@end
 
 @implementation PKHashtagState
 

--- a/src/PKMultiLineCommentState.m
+++ b/src/PKMultiLineCommentState.m
@@ -24,13 +24,9 @@
 #import <PEGKit/PKCommentState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
 #import "PKSymbolRootNode.h"
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizerState ()
 - (void)resetWithReader:(PKReader *)r;

--- a/src/PKMultiLineCommentState.m
+++ b/src/PKMultiLineCommentState.m
@@ -24,17 +24,10 @@
 #import <PEGKit/PKCommentState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
 #import "PKSymbolRootNode.h"
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (void)append:(PKUniChar)c;
-- (void)appendString:(NSString *)s;
-- (NSString *)bufferedString;
-@property (nonatomic) NSUInteger offset;
-@end
 
 @interface PKCommentState ()
 @property (nonatomic, retain) PKSymbolRootNode *rootNode;

--- a/src/PKNumberState.m
+++ b/src/PKNumberState.m
@@ -22,16 +22,12 @@
 
 #import <PEGKit/PKNumberState.h>
 #import <PEGKit/PKReader.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTokenizer.h>
 #import <PEGKit/PKSymbolState.h>
 #import <PEGKit/PKWhitespaceState.h>
 #import <PEGKit/PKTypes.h>
 #import "PKSymbolRootNode.h"
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizerState ()
 - (void)resetWithReader:(PKReader *)r;

--- a/src/PKNumberState.m
+++ b/src/PKNumberState.m
@@ -24,26 +24,11 @@
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTokenizer.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKSymbolState.h>
 #import <PEGKit/PKWhitespaceState.h>
 #import <PEGKit/PKTypes.h>
 #import "PKSymbolRootNode.h"
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
-
-- (PKUniChar)checkForPositiveNegativeFromReader:(PKReader *)r startingWith:(PKUniChar)cin;
-- (PKUniChar)checkForPrefixFromReader:(PKReader *)r startingWith:(PKUniChar)cin;
-- (PKUniChar)checkForSuffixFromReader:(PKReader *)r startingWith:(PKUniChar)cin tokenizer:(PKTokenizer *)t;
-- (void)parseAllDigitsFromReader:(PKReader *)r startingWith:(PKUniChar)cin;
-- (PKToken *)checkForErroneousMatchFromReader:(PKReader *)r tokenizer:(PKTokenizer *)t;
-- (void)applySuffixFromReader:(PKReader *)r;
-
-- (void)append:(PKUniChar)c;
-- (void)appendString:(NSString *)s;
-- (NSString *)bufferedString;
-@end
 
 @interface PKNumberState ()
 - (double)absorbDigitsFromReader:(PKReader *)r;
@@ -67,7 +52,6 @@
 
 @property (nonatomic, retain) NSString *prefix;
 @property (nonatomic, retain) NSString *suffix;
-@property (nonatomic) NSUInteger offset;
 @end
 
 @implementation PKNumberState {

--- a/src/PKQuoteState.m
+++ b/src/PKQuoteState.m
@@ -22,12 +22,8 @@
 
 #import <PEGKit/PKQuoteState.h>
 #import <PEGKit/PKReader.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizerState ()
 - (void)resetWithReader:(PKReader *)r;

--- a/src/PKQuoteState.m
+++ b/src/PKQuoteState.m
@@ -23,15 +23,8 @@
 #import <PEGKit/PKQuoteState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKToken+Subclass.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKTypes.h>
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (void)append:(PKUniChar)c;
-- (NSString *)bufferedString;
-- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
-@property (nonatomic) NSUInteger offset;
-@end
 
 @implementation PKQuoteState
 

--- a/src/PKSingleLineCommentState.m
+++ b/src/PKSingleLineCommentState.m
@@ -25,15 +25,8 @@
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
 #import <PEGKit/PKToken+Subclass.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKTypes.h>
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (void)append:(PKUniChar)c;
-- (void)appendString:(NSString *)s;
-- (NSString *)bufferedString;
-@property (nonatomic) NSUInteger offset;
-@end
 
 @interface PKSingleLineCommentState ()
 - (void)addStartMarker:(NSString *)start;

--- a/src/PKSingleLineCommentState.m
+++ b/src/PKSingleLineCommentState.m
@@ -24,12 +24,8 @@
 #import <PEGKit/PKCommentState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizerState ()
 - (void)resetWithReader:(PKReader *)r;

--- a/src/PKSymbolState.m
+++ b/src/PKSymbolState.m
@@ -21,14 +21,10 @@
 // THE SOFTWARE.
 
 #import <PEGKit/PKSymbolState.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
 #import "PKSymbolRootNode.h"
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizerState ()
 - (void)resetWithReader:(PKReader *)r;

--- a/src/PKSymbolState.m
+++ b/src/PKSymbolState.m
@@ -24,13 +24,8 @@
 #import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import "PKSymbolRootNode.h"
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
-@property (nonatomic) NSUInteger offset;
-@end
 
 @interface PKSymbolState ()
 - (PKToken *)symbolTokenWith:(PKUniChar)cin;

--- a/src/PKToken.m
+++ b/src/PKToken.m
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
 #import "NSString+PEGKitAdditions.h"
 
@@ -80,7 +80,6 @@ static PKTokenEOF *EOFToken = nil;
 @property (nonatomic, readwrite) PKTokenType tokenType;
 @property (nonatomic, readwrite, copy) id value;
 
-@property (nonatomic, readwrite) NSUInteger offset;
 @property (nonatomic, readwrite) NSUInteger lineNumber;
 @end
 

--- a/src/PKTokenizer.m
+++ b/src/PKTokenizer.m
@@ -21,15 +21,12 @@
 // THE SOFTWARE.
 
 #import <PEGKit/PEGKit.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 
 #define STATE_COUNT 256
 
 @interface PKToken ()
 @property (nonatomic, readwrite) NSUInteger lineNumber;
-@end
-
-@interface PKTokenizerState ()
-- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
 @end
 
 @interface PKTokenizer ()

--- a/src/PKTokenizerState.m
+++ b/src/PKTokenizerState.m
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 #import <PEGKit/PKTokenizerState.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKTokenizer.h>
 #import <PEGKit/PKReader.h>
 
@@ -31,14 +32,8 @@
 @end
 
 @interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (void)append:(PKUniChar)c;
-- (void)appendString:(NSString *)s;
-- (NSString *)bufferedString;
-- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
 
 @property (nonatomic, retain) NSMutableString *stringbuf;
-@property (nonatomic) NSUInteger offset;
 @property (nonatomic, retain) NSMutableArray *fallbackStates;
 @end
 

--- a/src/PKTwitterState.m
+++ b/src/PKTwitterState.m
@@ -24,12 +24,8 @@
 #import <PEGKit/PKTwitterState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizerState ()
 - (void)resetWithReader:(PKReader *)r;

--- a/src/PKTwitterState.m
+++ b/src/PKTwitterState.m
@@ -24,16 +24,9 @@
 #import <PEGKit/PKTwitterState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (void)append:(PKUniChar)c;
-- (NSString *)bufferedString;
-- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
-@property (nonatomic) NSUInteger offset;
-@end
 
 @interface PKTwitterState ()
 

--- a/src/PKURLState.m
+++ b/src/PKURLState.m
@@ -23,19 +23,12 @@
 #import <PEGKit/PKURLState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
 
 // Gruber original
 //  \b(([\w-]+://?|www[.])[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|/)))
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (void)append:(PKUniChar)c;
-- (NSString *)bufferedString;
-- (PKTokenizerState *)nextTokenizerStateFor:(PKUniChar)c tokenizer:(PKTokenizer *)t;
-@property (nonatomic) NSUInteger offset;
-@end
 
 @interface PKURLState ()
 - (BOOL)parseWWWFromReader:(PKReader *)r;

--- a/src/PKURLState.m
+++ b/src/PKURLState.m
@@ -23,15 +23,11 @@
 #import <PEGKit/PKURLState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
 
 // Gruber original
 //  \b(([\w-]+://?|www[.])[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|/)))
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizerState ()
 - (void)resetWithReader:(PKReader *)r;

--- a/src/PKWhitespaceState.m
+++ b/src/PKWhitespaceState.m
@@ -23,6 +23,7 @@
 #import <PEGKit/PKWhitespaceState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
 
@@ -31,13 +32,6 @@
 
 @interface PKTokenizer ()
 @property (nonatomic, readwrite) NSUInteger lineNumber;
-@end
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (void)append:(PKUniChar)c;
-- (NSString *)bufferedString;
-@property (nonatomic) NSUInteger offset;
 @end
 
 @interface PKWhitespaceState ()

--- a/src/PKWhitespaceState.m
+++ b/src/PKWhitespaceState.m
@@ -23,15 +23,11 @@
 #import <PEGKit/PKWhitespaceState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
 
 #define PKTRUE (id)kCFBooleanTrue
 #define PKFALSE (id)kCFBooleanFalse
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizer ()
 @property (nonatomic, readwrite) NSUInteger lineNumber;

--- a/src/PKWordState.m
+++ b/src/PKWordState.m
@@ -23,15 +23,11 @@
 #import <PEGKit/PKWordState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
-#import <PEGKit/PKToken.h>
+#import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
 
 #define PKTRUE (id)kCFBooleanTrue
 #define PKFALSE (id)kCFBooleanFalse
-
-@interface PKToken ()
-@property (nonatomic, readwrite) NSUInteger offset;
-@end
 
 @interface PKTokenizerState ()
 - (void)resetWithReader:(PKReader *)r;

--- a/src/PKWordState.m
+++ b/src/PKWordState.m
@@ -23,18 +23,12 @@
 #import <PEGKit/PKWordState.h>
 #import <PEGKit/PKReader.h>
 #import <PEGKit/PKTokenizer.h>
+#import <PEGKit/PKTokenizerState+Subclass.h>
 #import <PEGKit/PKToken+Subclass.h>
 #import <PEGKit/PKTypes.h>
 
 #define PKTRUE (id)kCFBooleanTrue
 #define PKFALSE (id)kCFBooleanFalse
-
-@interface PKTokenizerState ()
-- (void)resetWithReader:(PKReader *)r;
-- (void)append:(PKUniChar)c;
-- (NSString *)bufferedString;
-@property (nonatomic) NSUInteger offset;
-@end
 
 @interface PKWordState () 
 - (BOOL)isWordChar:(PKUniChar)c;


### PR DESCRIPTION
Move PKToken and PKTokenizerState internal declarations to +Subclass header files.

This avoids repeating the same declarations for every subclass.  This removes 28 blocks of duplicated declarations.
