### PR TITLE
Feature/fix smart edit annoyance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ DerivedData
 
 #CocoaPods
 Pods
+PEGKit.xcworkspace/xcshareddata

--- a/PEGKit.xcodeproj/project.pbxproj
+++ b/PEGKit.xcodeproj/project.pbxproj
@@ -2284,8 +2284,9 @@
 				);
 				INFOPLIST_FILE = "ParserGenApp/ParserGenApp-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -2316,8 +2317,9 @@
 				);
 				INFOPLIST_FILE = "ParserGenApp/ParserGenApp-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -2474,6 +2476,7 @@
 				INFOPLIST_FILE = "res/PEGKit-Info.plist";
 				LLVM_LTO = NO;
 				PRODUCT_NAME = PEGKit;
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = framework;
 			};
@@ -2499,6 +2502,7 @@
 				INFOPLIST_FILE = "res/PEGKit-Info.plist";
 				LLVM_LTO = NO;
 				PRODUCT_NAME = PEGKit;
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = framework;
 			};

--- a/ParserGenApp/PGDocument.m
+++ b/ParserGenApp/PGDocument.m
@@ -37,7 +37,7 @@
     if (self) {
         self.factory = [PGParserFactory factory];
         _factory.collectTokenKinds = YES;
-        
+
         self.enableARC = YES;
         self.enableHybridDFA = YES;
         self.enableMemoization = YES;
@@ -87,6 +87,12 @@
     [super windowControllerDidLoadNib:wc];
     
     [_textView setFont:[NSFont fontWithName:@"Monaco" size:12.0]];
+    
+    // Since maverics the check boxes in interface builder do not work to
+    // turn off smart substitution on dashes and quotes
+    [_textView setAutomaticDashSubstitutionEnabled:NO];
+    [_textView setAutomaticQuoteSubstitutionEnabled:NO];
+    
     [self focusTextView];
 }
 


### PR DESCRIPTION
The attached changes are for issue #44 https://github.com/itod/pegkit/issues/44

The important bit of the change is adding: 

```
    // Since maverics the check boxes in interface builder do not work to
    // turn off smart substitution on dashes and quotes
    [_textView setAutomaticDashSubstitutionEnabled:NO];
    [_textView setAutomaticQuoteSubstitutionEnabled:NO];
```
in PGDocument.m: - (void)windowControllerDidLoadNib:(NSWindowController *)w


This pull request also fixed build error due to old SDK version.
