### PR TITLE
Maintain Undo History after save or generate

### DIFF
--- a/ParserGenApp/PGDocument.h
+++ b/ParserGenApp/PGDocument.h
@@ -30,7 +30,7 @@
 
 @property (nonatomic, copy) NSString *destinationPath;
 @property (nonatomic, copy) NSString *parserName;
-@property (nonatomic, copy) NSString *grammar;
+//@property (nonatomic, copy) NSString *grammar;
 @property (nonatomic, assign) BOOL busy;
 @property (nonatomic, retain) NSError *error;
 

--- a/ParserGenApp/PGDocument.m
+++ b/ParserGenApp/PGDocument.m
@@ -48,9 +48,6 @@
         
         self.delegatePreMatchCallbacksOn = PGParserFactoryDelegateCallbacksOnNone;
         self.delegatePostMatchCallbacksOn = PGParserFactoryDelegateCallbacksOnAll;
-        
-        NSString *path = [[NSBundle mainBundle] pathForResource:@"expression" ofType:@"grammar"];
-        self.grammar = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
     }
     return self;
 }
@@ -59,7 +56,6 @@
 - (void)dealloc {
     self.destinationPath = nil;
     self.parserName = nil;
-    self.grammar = nil;
     
     self.textView = nil;
     
@@ -86,6 +82,13 @@
 - (void)windowControllerDidLoadNib:(NSWindowController *)wc {
     [super windowControllerDidLoadNib:wc];
     
+    NSString *path = [[NSBundle mainBundle] pathForResource:@"expression" ofType:@"grammar"];
+    NSString *grammarVal = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+    if (grammarVal) {
+        [self.textView setString:grammarVal];
+    }
+
+    
     // Since maverics the check boxes in interface builder do not work to
     // turn off smart substitution on dashes and quotes
     [_textView setAutomaticDashSubstitutionEnabled:NO];
@@ -106,7 +109,8 @@
     NSMutableDictionary *tab = [NSMutableDictionary dictionaryWithCapacity:9];
     
     if (_destinationPath) tab[@"destinationPath"] = _destinationPath;
-    if (_grammar) tab[@"grammar"] = _grammar;
+    NSString* grammarVal = [self.textView string];
+    if (grammarVal) tab[@"grammar"] = grammarVal;
     if (_parserName) tab[@"parserName"] = _parserName;
     tab[@"enableARC"] = @(_enableARC);
     tab[@"enableHybridDFA"] = @(_enableHybridDFA);
@@ -129,7 +133,7 @@
     //NSLog(@"%@", tab);
     
     self.destinationPath = tab[@"destinationPath"];
-    self.grammar = tab[@"grammar"];
+    [self.textView setString:tab[@"grammar"]];
     self.parserName = tab[@"parserName"];
     self.enableARC = [tab[@"enableARC"] boolValue];
     self.enableHybridDFA = [tab[@"enableHybridDFA"] boolValue];
@@ -148,7 +152,7 @@
 - (IBAction)generate:(id)sender {
     NSString *destPath = [[_destinationPath copy] autorelease];
     NSString *parserName = [[_parserName copy] autorelease];
-    NSString *grammar = [[_grammar copy] autorelease];
+    NSString *grammar = [self.textView string];
     
     if (![destPath length] || ![parserName length] || ![grammar length]) {
         NSBeep();
@@ -230,7 +234,7 @@
 
 - (void)generateWithDestinationPath:(NSString *)destPath parserName:(NSString *)parserName grammar:(NSString *)grammar {
     NSError *err = nil;
-    self.root = (id)[_factory ASTFromGrammar:_grammar error:&err];
+    self.root = (id)[_factory ASTFromGrammar:grammar error:&err];
     if (err) {
         self.error = err;
         goto done;

--- a/ParserGenApp/en.lproj/PGDocument.xib
+++ b/ParserGenApp/en.lproj/PGDocument.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9059"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PGDocument">
@@ -57,29 +58,17 @@
                         <rect key="frame" x="20" y="20" width="554" height="227"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="xnX-md-NJo">
-                            <rect key="frame" x="1" y="1" width="552" height="225"/>
+                            <rect key="frame" x="1" y="1" width="537" height="225"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <textView importsGraphics="NO" richText="NO" findStyle="panel" allowsUndo="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" spellingCorrection="YES" smartInsertDelete="YES" id="100032">
+                                <textView importsGraphics="NO" richText="NO" findStyle="panel" allowsUndo="YES" allowsNonContiguousLayout="YES" spellingCorrection="YES" smartInsertDelete="YES" id="100032">
                                     <rect key="frame" x="0.0" y="0.0" width="552" height="225"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                    <size key="minSize" width="552" height="225"/>
+                                    <size key="minSize" width="537" height="225"/>
                                     <size key="maxSize" width="554" height="10000000"/>
                                     <color key="insertionPointColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                    <size key="minSize" width="552" height="225"/>
-                                    <size key="maxSize" width="554" height="10000000"/>
                                     <connections>
-                                        <binding destination="-2" name="editable" keyPath="busy" id="100072">
-                                            <dictionary key="options">
-                                                <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                            </dictionary>
-                                        </binding>
-                                        <binding destination="-2" name="value" keyPath="grammar" id="100056">
-                                            <dictionary key="options">
-                                                <bool key="NSContinuouslyUpdatesValue" value="YES"/>
-                                            </dictionary>
-                                        </binding>
                                         <outlet property="nextKeyView" destination="100041" id="100060"/>
                                     </connections>
                                 </textView>
@@ -91,7 +80,7 @@
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="100034">
-                            <rect key="frame" x="537" y="1" width="16" height="225"/>
+                            <rect key="frame" x="538" y="1" width="15" height="225"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                     </scrollView>


### PR DESCRIPTION
This is a fix for issue #52 

* Removes the `grammar`<->NSTextView KVO. 
* Gets rid of enable/disable state for `textView` since it breaks undo history and I don't think it actually adds any value. 
* Now uses `[self.textView string]` as the authoritative state of the NSTextView (grammar).

After this change undo history is maintained after `generate` or `File`->`Save`.